### PR TITLE
Page-Dying

### DIFF
--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -76,7 +76,7 @@ class ProductActions extends Component {
     addProduct() {
         const {
             addProduct, product, product: {
-                variants,
+                variants
             }, configurableVariantIndex
         } = this.props;
         const { itemCount } = this.state;
@@ -85,7 +85,7 @@ class ProductActions extends Component {
             // mixing product data with variant to work properly in cart
             const configurableProduct = {
                 ...product,
-                configurableVariantIndex,
+                configurableVariantIndex
             };
 
             addProduct({ product: configurableProduct, quantity: itemCount });
@@ -163,8 +163,17 @@ class ProductActions extends Component {
         );
     }
 
+    /**
+     * Render configurable swatch, return null if configurable does not exist by variant or not yet loaded
+     */
     renderConfigurableSwatches() {
-        const { product: { configurable_options, variants }, configurableVariantIndex } = this.props;
+        const { product: { configurable_options, variants }, configurableVariantIndex, areDetailsLoaded } = this.props;
+        const configurableExists = variants[configurableVariantIndex] && areDetailsLoaded;
+
+        if (!configurableExists) {
+            return null;
+        }
+
         const { product: currentConfigurableVariant } = variants[configurableVariantIndex];
 
         const renderAvailableValues = (configurableOption) => {
@@ -293,7 +302,8 @@ ProductActions.propTypes = {
     addProduct: PropTypes.func.isRequired,
     availableFilters: PropTypes.arrayOf(PropTypes.shape).isRequired,
     configurableVariantIndex: PropTypes.number.isRequired,
-    updateConfigurableVariantIndex: PropTypes.func.isRequired
+    updateConfigurableVariantIndex: PropTypes.func.isRequired,
+    areDetailsLoaded: PropTypes.bool.isRequired
 };
 
 export default ProductActions;

--- a/src/app/component/ProductDetails/ProductDetails.component.js
+++ b/src/app/component/ProductDetails/ProductDetails.component.js
@@ -10,10 +10,13 @@ import './ProductDetails.style';
  * @class ProductDetails
  */
 class ProductDetails extends Component {
+    /**
+     * Render product SKU only when it's loaded
+     */
     renderSku() {
-        const { configurableVariantIndex, product: { variants } } = this.props;
+        const { product: { variants }, areDetailsLoaded, configurableVariantIndex } = this.props;
 
-        if (variants) {
+        if (variants && variants[configurableVariantIndex] && areDetailsLoaded) {
             const { product } = variants[configurableVariantIndex];
 
             return (
@@ -73,7 +76,8 @@ class ProductDetails extends Component {
 
 ProductDetails.propTypes = {
     product: ProductType.isRequired,
-    configurableVariantIndex: PropTypes.number.isRequired
+    configurableVariantIndex: PropTypes.number.isRequired,
+    areDetailsLoaded: PropTypes.bool.isRequired
 };
 
 export default ProductDetails;

--- a/src/app/route/ProductPage/ProductPage.component.js
+++ b/src/app/route/ProductPage/ProductPage.component.js
@@ -98,9 +98,9 @@ class ProductPage extends Component {
      */
     getThumbnail(currentVariantIndex, dataSource) {
         const { thumbnail, variants } = dataSource;
-        const variantThumbnail = (variants && variants[ currentVariantIndex ])
-            ? variants[ currentVariantIndex ].product.thumbnail
-            : null;
+        const variantThumbnail = variants
+            && variants[ currentVariantIndex ]
+            && variants[ currentVariantIndex ].product.thumbnail;
         return variantThumbnail || thumbnail;
     }
 

--- a/src/app/route/ProductPage/ProductPage.component.js
+++ b/src/app/route/ProductPage/ProductPage.component.js
@@ -98,7 +98,9 @@ class ProductPage extends Component {
      */
     getThumbnail(currentVariantIndex, dataSource) {
         const { thumbnail, variants } = dataSource;
-        const variantThumbnail = variants ? variants[ currentVariantIndex ].product.thumbnail : null;
+        const variantThumbnail = (variants && variants[ currentVariantIndex ])
+            ? variants[ currentVariantIndex ].product.thumbnail
+            : null;
         return variantThumbnail || thumbnail;
     }
 
@@ -174,6 +176,7 @@ class ProductPage extends Component {
                           product={ dataSource }
                           availableFilters={ filters }
                           configurableVariantIndex={ configurableVariantIndex }
+                          areDetailsLoaded={ areDetailsLoaded }
                           updateConfigurableVariantIndex={ index => this.setState({ configurableVariantIndex: index }) }
                         />
                     </ContentWrapper>


### PR DESCRIPTION
Fixed blank page when switching between related products
-Configurable color swatch is initialised only if variant exists and product details are loaded
-Product sku is rendered when it has been loaded
-getthumbnail now checks if configurable exists