### PR TITLE
Fix placeholder image loading of Safari browser

### DIFF
--- a/src/app/component/Image/Image.component.js
+++ b/src/app/component/Image/Image.component.js
@@ -24,7 +24,7 @@ class Image extends Component {
 
     componentDidMount() {
         if ('requestIdleCallback' in window) {
-            window.requestIdleCallback(() => this.showImage());
+            window.requestIdleCallback(() => this.showImage(), { timeout: 1000 });
         } else {
             setTimeout(this.showImage(), 1);
         }

--- a/src/app/component/ProductCard/ProductCard.style.scss
+++ b/src/app/component/ProductCard/ProductCard.style.scss
@@ -80,9 +80,9 @@
         &_isLoaded.Image_isReal {
             @keyframes maskAnimation {
                 0% {
-                  mask-size: 100%;
-                  mask-position: center;
-                  animation-timing-function: ease-in-out;
+                    mask-size: 100%;
+                    mask-position: center;
+                    animation-timing-function: ease-in-out;
                 }
             
                 50% {
@@ -92,7 +92,9 @@
                 }
                 
                 100% {
-                    mask: radial-gradient(ellipse, black 100%, transparent 100%, transparent 100%), radial-gradient(circle, black 100%, transparent 100%, transparent 100%);
+                    mask-position: center;
+                    mask-size: 1000%;
+                    animation-timing-function: ease-in-out;
                 }
               }
 


### PR DESCRIPTION
- Fixed image transition from primitive to real image on Safari browser
- Added timeout to requestIdle, so if it is not supported or takes more than 1 sec will trigger image loading anyway

Fixes #25 