### PR TITLE
Show a category tree in the "Available categories"

### DIFF
--- a/src/app/component/CategoriesList/CategoriesList.component.js
+++ b/src/app/component/CategoriesList/CategoriesList.component.js
@@ -3,6 +3,7 @@ import TextPlaceholder from 'Component/TextPlaceholder';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { CategoryTreeType } from 'Type/Category';
+import { getUrlParam } from 'Util/Url';
 import './CategoriesList.style';
 
 /**
@@ -18,10 +19,19 @@ class CategoriesList extends Component {
         );
     }
 
-    renderSubCategory({ id, name, url_path }) {
+    renderSubCategory({
+        id,
+        name,
+        url_path,
+        children
+    }, isParent) {
+        const { location, match } = this.props;
+        const isSelected = getUrlParam(match, location) === url_path;
+
         return (
-            <li block="CategoriesList" elem="Category" key={ id }>
+            <li block="CategoriesList" elem="Category" key={ id } mods={ { isSelected, isParent } }>
                 { this.renderCategoryLabel(name, url_path) }
+                { children && <ul>{ children.map(child => this.renderSubCategory(child)) }</ul> }
             </li>
         );
     }
@@ -33,7 +43,7 @@ class CategoriesList extends Component {
             if (children.length) {
                 return (
                     <ul>
-                        { children.map(child => this.renderSubCategory(child)) }
+                        { children.map(child => this.renderSubCategory(child, true)) }
                     </ul>
                 );
             }
@@ -61,7 +71,13 @@ class CategoriesList extends Component {
 
 CategoriesList.propTypes = {
     availableFilters: PropTypes.arrayOf(PropTypes.object).isRequired,
-    category: CategoryTreeType.isRequired
+    category: CategoryTreeType.isRequired,
+    location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired
+    }).isRequired,
+    match: PropTypes.shape({
+        path: PropTypes.string.isRequired
+    }).isRequired
 };
 
 export default CategoriesList;

--- a/src/app/component/CategoriesList/CategoriesList.component.js
+++ b/src/app/component/CategoriesList/CategoriesList.component.js
@@ -26,12 +26,15 @@ class CategoriesList extends Component {
         children
     }, isParent) {
         const { location, match } = this.props;
-        const isSelected = getUrlParam(match, location) === url_path;
+        const currentPath = getUrlParam(match, location);
+        const isSelected = currentPath === url_path;
+        const isParentExpanded = currentPath.substring(0, currentPath.lastIndexOf('/')) === url_path
+        || (isParent && isSelected);
 
         return (
             <li block="CategoriesList" elem="Category" key={ id } mods={ { isSelected, isParent } }>
                 { this.renderCategoryLabel(name, url_path) }
-                { children && <ul>{ children.map(child => this.renderSubCategory(child)) }</ul> }
+                { isParentExpanded && children && <ul>{ children.map(child => this.renderSubCategory(child)) }</ul> }
             </li>
         );
     }

--- a/src/app/component/CategoriesList/CategoriesList.component.js
+++ b/src/app/component/CategoriesList/CategoriesList.component.js
@@ -32,7 +32,7 @@ class CategoriesList extends Component {
         || (isParent && isSelected);
 
         return (
-            <li block="CategoriesList" elem="Category" key={ id } mods={ { isSelected, isParent } }>
+            <li block="CategoriesList" elem="Category" key={ id } mods={ { isSelected } }>
                 { this.renderCategoryLabel(name, url_path) }
                 { isParentExpanded && children && <ul>{ children.map(child => this.renderSubCategory(child)) }</ul> }
             </li>
@@ -65,7 +65,7 @@ class CategoriesList extends Component {
 
         return (
             <div block="CategoriesList">
-                <h3><TextPlaceholder content={ isLoadedOnce ? 'Available categories' : '' } /></h3>
+                <h3><TextPlaceholder content={ isLoadedOnce ? 'Categories' : '' } /></h3>
                 { this.renderCategories(isLoadedOnce) }
             </div>
         );

--- a/src/app/component/CategoriesList/CategoriesList.style.scss
+++ b/src/app/component/CategoriesList/CategoriesList.style.scss
@@ -22,7 +22,6 @@
         li {
             list-style-type: circle;
             padding-left: 2em;
-
         }
 
         a {

--- a/src/app/component/CategoriesList/CategoriesList.style.scss
+++ b/src/app/component/CategoriesList/CategoriesList.style.scss
@@ -18,11 +18,16 @@
 
     & &-Category {
         li {
-            padding-left: 2em;
+            padding-left: 1.5em;
+        }
+
+        li:last-child {
+            margin: 0;
         }
 
         a {
             transition: color 150ms ease-in;
+            line-height: 1.5;
 
             &:hover,
             &:focus {
@@ -33,12 +38,6 @@
         &_isSelected {
             > a {
                 color: var(--color-primary-base);
-            }
-        }
-
-        &_isParent {
-            > a {
-                line-height: 2.5;
             }
         }
     }

--- a/src/app/component/CategoriesList/CategoriesList.style.scss
+++ b/src/app/component/CategoriesList/CategoriesList.style.scss
@@ -17,10 +17,7 @@
     }
 
     & &-Category {
-        list-style-type: initial;
-
         li {
-            list-style-type: circle;
             padding-left: 2em;
         }
 

--- a/src/app/component/CategoriesList/CategoriesList.style.scss
+++ b/src/app/component/CategoriesList/CategoriesList.style.scss
@@ -17,25 +17,32 @@
     }
 
     & &-Category {
-        border-radius: 3px;
-        display: inline-block;
-        background-color: var(--color-primary-light);
-        text-transform: lowercase;
-        margin-right: .5rem;
-        transition: background-color 150ms ease-in;
+        list-style-type: initial;
 
-        &:hover {
-            background-color: var(--color-primary-base);
+        li {
+            list-style-type: circle;
+            padding-left: 2em;
+
         }
 
         a {
-            padding: .3rem .6rem;
             transition: color 150ms ease-in;
-            display: block;
 
             &:hover,
             &:focus {
-                color: var(--color-text-white);
+                color: var(--color-primary-base);
+            }
+        }
+
+        &_isSelected {
+            > a {
+                color: var(--color-primary-base);
+            }
+        }
+
+        &_isParent {
+            > a {
+                line-height: 2.5;
             }
         }
     }

--- a/src/app/query/Category/Category.js
+++ b/src/app/query/Category/Category.js
@@ -11,13 +11,12 @@ class CategoryQuery {
      * @return {Field} Category query
      * @memberof CategoryQuery
      */
-    getQuery(options) {
-        const { categoryUrlPath } = options;
+    getQuery() {
         const categoryFields = this._prepareChildrenFields();
         const children = new Field('children').addFieldList(categoryFields);
 
         const field = new Field('category')
-            .addArgument('url_path', 'String!', categoryUrlPath)
+            .addArgument('id', 'Int!', '2') // TODO: When config is available get value from config
             .addFieldList(categoryFields)
             .addField(children);
 
@@ -33,10 +32,15 @@ class CategoryQuery {
         const breadcrumbs = new Field('breadcrumbs')
             .addFieldList(['category_name', 'category_url_key', 'category_level']);
 
+        const children = new Field('children')
+            .addFieldList(['id', 'name', 'description', 'url_path',
+                'image', 'url_key', 'product_count',
+                'meta_title', 'meta_description', breadcrumbs]);
+
         return [
             'id', 'name', 'description', 'url_path',
             'image', 'url_key', 'product_count',
-            'meta_title', 'meta_description', breadcrumbs
+            'meta_title', 'meta_description', breadcrumbs, children
         ];
     }
 }

--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -173,7 +173,7 @@ class CategoryPage extends Component {
             productsLoaded: items.length,
             // TODO: adding configurable data request (as in PDP) to query, should make a seperate/more specific query
             getConfigurableData: true,
-            isCategoryLoaded: Object.entries(category).length !== 0
+            isCategoryLoaded: (Object.entries(category).length)
         };
 
         const stateUpdate = {

--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -143,7 +143,12 @@ class CategoryPage extends Component {
      * @return {void}
      */
     requestCategory() {
-        const { requestCategory, location, items } = this.props;
+        const {
+            requestCategory,
+            location,
+            items,
+            category
+        } = this.props;
         const {
             sortKey,
             sortDirection,
@@ -167,7 +172,8 @@ class CategoryPage extends Component {
             sortDirection: querySortDirection || sortDirection,
             productsLoaded: items.length,
             // TODO: adding configurable data request (as in PDP) to query, should make a seperate/more specific query
-            getConfigurableData: true
+            getConfigurableData: true,
+            isCategoryLoaded: Object.entries(category).length !== 0
         };
 
         const stateUpdate = {
@@ -310,11 +316,13 @@ class CategoryPage extends Component {
     render() {
         const {
             category,
+            categoryList,
             items,
             totalItems,
             sortFields,
             filters,
             location,
+            match,
             history,
             isLoading
         } = this.props;
@@ -353,7 +361,9 @@ class CategoryPage extends Component {
                         />
                         <CategoriesList
                           availableFilters={ filters }
-                          category={ category }
+                          category={ categoryList }
+                          location={ location }
+                          match={ match }
                         />
                     </aside>
                     <CategoryDetails
@@ -388,6 +398,7 @@ CategoryPage.propTypes = {
         push: PropTypes.func.isRequired
     }).isRequired,
     category: CategoryTreeType.isRequired,
+    categoryList: CategoryTreeType.isRequired,
     items: ItemsType.isRequired,
     totalItems: PropTypes.number.isRequired,
     location: PropTypes.shape({

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -5,6 +5,7 @@ import CategoryPage from './CategoryPage.component';
 
 const mapStateToProps = state => ({
     category: state.CategoryReducer.category,
+    categoryList: state.CategoryReducer.categoryList,
     items: state.CategoryReducer.items,
     totalItems: state.CategoryReducer.totalItems,
     sortFields: state.CategoryReducer.sortFields,

--- a/src/app/store/Category/Category.action.js
+++ b/src/app/store/Category/Category.action.js
@@ -1,5 +1,6 @@
 export const UPDATE_CATEGORY_PRODUCT_LIST = 'UPDATE_CATEGORY_PRODUCT_LIST';
-export const UPDATE_CATEGORY_DETAILS = 'UPDATE_CATEGORY_DETAILS';
+export const UPDATE_CATEGORY_LIST = 'UPDATE_CATEGORY_LIST';
+export const UPDATE_CURRENT_CATEGORY = 'UPDATE_CURRENT_CATEGORY';
 export const APPEND_CATEGORY_PRODUCT_LIST = 'APPEND_CATEGORY_PRODUCT_LIST';
 export const UPDATE_LOAD_STATUS = 'UPDATE_LOAD_STATUS';
 
@@ -33,9 +34,19 @@ const appendCategoryProductList = items => ({
  * @param {Array<Object>} subCategories List subcategories
  * @return {void}
  */
-const updateCategoryDetails = category => ({
-    type: UPDATE_CATEGORY_DETAILS,
-    category
+const updateCategoryList = categoryList => ({
+    type: UPDATE_CATEGORY_LIST,
+    categoryList
+});
+
+/**
+ * Update Current Category
+ * @param {String} categoryUrlPath url path Main Category object
+ * @return {void}
+ */
+const updateCurrentCategory = categoryUrlPath => ({
+    type: UPDATE_CURRENT_CATEGORY,
+    categoryUrlPath
 });
 
 /**
@@ -49,5 +60,5 @@ const updateLoadStatus = status => ({
 });
 
 export {
-    updateCategoryProductList, updateCategoryDetails, appendCategoryProductList, updateLoadStatus
+    updateCategoryProductList, updateCategoryList, updateCurrentCategory, appendCategoryProductList, updateLoadStatus
 };

--- a/src/app/store/Category/Category.dispatcher.js
+++ b/src/app/store/Category/Category.dispatcher.js
@@ -27,11 +27,12 @@ class CategoryDispatcher extends RequestDispatcher {
                 filters
             }
         } = data;
+        const { categoryUrlPath } = options;
 
         if (category) { // If category details are updated, reset all data
             dispatch(updateCategoryProductList(items, total_count, sort_fields, filters));
             dispatch(updateCategoryList(category));
-            dispatch(updateCurrentCategory(options.categoryUrlPath));
+            dispatch(updateCurrentCategory(categoryUrlPath));
         } else if (filters || sort_fields) {
             dispatch(updateCategoryProductList(items, total_count, sort_fields, filters));
         } else {

--- a/src/app/store/Category/Category.reducer.js
+++ b/src/app/store/Category/Category.reducer.js
@@ -53,7 +53,7 @@ const CategoryReducer = (state = initialState, action) => {
         };
 
     case UPDATE_CURRENT_CATEGORY:
-        const { categoryList: test } = state;
+        const { categoryList: stateCategoryList } = state;
         const flattendCategories = {};
 
         const deleteProperty = (key, { [key]: _, ...newObj }) => newObj;
@@ -67,7 +67,7 @@ const CategoryReducer = (state = initialState, action) => {
                 });
             }
         };
-        flattenCategory(test);
+        flattenCategory(stateCategoryList);
 
         return {
             ...state,

--- a/src/app/store/Category/Category.reducer.js
+++ b/src/app/store/Category/Category.reducer.js
@@ -67,6 +67,7 @@ const CategoryReducer = (state = initialState, action) => {
                 });
             }
         };
+
         flattenCategory(stateCategoryList);
 
         return {

--- a/src/app/store/Category/Category.reducer.js
+++ b/src/app/store/Category/Category.reducer.js
@@ -1,6 +1,7 @@
 import {
     UPDATE_CATEGORY_PRODUCT_LIST,
-    UPDATE_CATEGORY_DETAILS,
+    UPDATE_CATEGORY_LIST,
+    UPDATE_CURRENT_CATEGORY,
     APPEND_CATEGORY_PRODUCT_LIST,
     UPDATE_LOAD_STATUS
 } from './Category.action';
@@ -9,6 +10,7 @@ const initialState = {
     items: [],
     totalItems: 0,
     category: {},
+    categoryList: {},
     sortFields: {},
     filters: [],
     isLoading: true
@@ -18,10 +20,11 @@ const CategoryReducer = (state = initialState, action) => {
     const {
         totalItems,
         items,
-        category,
+        categoryList,
         sortFields,
         filters,
-        isLoading
+        isLoading,
+        categoryUrlPath
     } = action;
 
     switch (action.type) {
@@ -43,10 +46,32 @@ const CategoryReducer = (state = initialState, action) => {
             ]
         };
 
-    case UPDATE_CATEGORY_DETAILS:
+    case UPDATE_CATEGORY_LIST:
         return {
             ...state,
-            category
+            categoryList
+        };
+
+    case UPDATE_CURRENT_CATEGORY:
+        const { categoryList: test } = state;
+        const flattendCategories = {};
+
+        const deleteProperty = (key, { [key]: _, ...newObj }) => newObj;
+        const flattenCategory = (category) => {
+            const { children } = category;
+
+            if (children) {
+                children.forEach((element) => {
+                    flattenCategory(element);
+                    flattendCategories[element.url_path] = deleteProperty('children', element);
+                });
+            }
+        };
+        flattenCategory(test);
+
+        return {
+            ...state,
+            category: flattendCategories[categoryUrlPath]
         };
 
     case UPDATE_LOAD_STATUS:

--- a/src/app/store/Category/index.js
+++ b/src/app/store/Category/index.js
@@ -2,24 +2,28 @@ import CategoryReducer from './Category.reducer';
 import CategoryDispatcher from './Category.dispatcher';
 import {
     UPDATE_CATEGORY_PRODUCT_LIST,
-    UPDATE_CATEGORY_DETAILS,
+    UPDATE_CATEGORY_LIST,
     APPEND_CATEGORY_PRODUCT_LIST,
     UPDATE_LOAD_STATUS,
+    UPDATE_CURRENT_CATEGORY,
     updateCategoryProductList,
-    updateCategoryDetails,
+    updateCategoryList,
     appendCategoryProductList,
-    updateLoadStatus
+    updateLoadStatus,
+    updateCurrentCategory
 } from './Category.action';
 
 export {
     CategoryReducer,
     CategoryDispatcher,
     UPDATE_CATEGORY_PRODUCT_LIST,
-    UPDATE_CATEGORY_DETAILS,
+    UPDATE_CATEGORY_LIST,
     APPEND_CATEGORY_PRODUCT_LIST,
     UPDATE_LOAD_STATUS,
+    UPDATE_CURRENT_CATEGORY,
     updateCategoryProductList,
-    updateCategoryDetails,
+    updateCategoryList,
     appendCategoryProductList,
-    updateLoadStatus
+    updateLoadStatus,
+    updateCurrentCategory
 };


### PR DESCRIPTION
Fixes issue #5 
- Made categories load only once on first category page initialization.
- Category tree is displayed based on all available categories.
- Categories are expanded only if parent category or its children is selected.