### PR TITLE
Add number as acceptable content type

### DIFF
--- a/src/app/component/TextPlaceholder/TextPlaceholder.component.js
+++ b/src/app/component/TextPlaceholder/TextPlaceholder.component.js
@@ -26,7 +26,10 @@ class TextPlaceholder extends Component {
 }
 
 TextPlaceholder.propTypes = {
-    content: PropTypes.string,
+    content: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
     length: PropTypes.oneOf([
         'short',
         'medium',


### PR DESCRIPTION
Quick note - the only 'number' that is actually passed to the TextPlaceholder is price, which has the PropType of string anyways.
Are we actually planning to to use TextPlaceholder for pure numbers?