### PR TITLE
Fix sync between qty of mini-cart and cart

### DIFF
--- a/src/app/component/Field/Field.component.js
+++ b/src/app/component/Field/Field.component.js
@@ -74,7 +74,7 @@ class Field extends Component {
         const { value: stateValue } = state;
 
         if (value !== stateValue) {
-            return { stateValue };
+            return { value };
         }
 
         return null;


### PR DESCRIPTION
This fixes #109 

@alfredsgenkins you for some reason changed `value` to `stateValue` which caused this issue. I have checked form validations and product qty selection, but maybe there were other reasons you changed it.