### PR TITLE
Will export all reducers for use in theme overrides

### DIFF
--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -27,7 +27,7 @@ import { SearchBarReducer } from 'Store/SearchBar';
 import { MyAccountReducer } from 'Store/MyAccount';
 import { CountryReducer } from 'Store/Country';
 
-const reducers = combineReducers({
+const reducers = {
     CmsBlocksAndSliderReducer,
     CmsPageReducer,
     CategoryReducer,
@@ -41,10 +41,12 @@ const reducers = combineReducers({
     SearchBarReducer,
     MyAccountReducer,
     CountryReducer
-});
+};
+
+const combinedReducers = combineReducers(reducers);
 
 const store = createStore(
-    reducers,
+    combinedReducers,
     ( // enable Redux dev-tools only in development
         process.env.NODE_ENV === 'development'
         && window.__REDUX_DEVTOOLS_EXTENSION__
@@ -52,3 +54,5 @@ const store = createStore(
 );
 
 export default store;
+
+export { reducers };


### PR DESCRIPTION
This approach lets import all base reducers in theme overrides.

Example usage:

```
// Global reducers
import { reducers as baseReducers } from 'SourceStore';

// Our project specific reducers
import { CustomReducer } from 'Store/Custom';

const reducers = combineReducers({
    ...baseReducers,
    CustomReducer
});
```