### PR TITLE
Changed product selection

### DIFF
--- a/src/app/component/ProductDetails/ProductDetails.component.js
+++ b/src/app/component/ProductDetails/ProductDetails.component.js
@@ -28,7 +28,9 @@ class ProductDetails extends Component {
         const { product: { variants, sku }, areDetailsLoaded, configurableVariantIndex } = this.props;
 
         if (areDetailsLoaded) {
-            const { product } = variants && configurableVariantIndex ? variants[configurableVariantIndex] : '';
+            const { product } = configurableVariantIndex >= 0
+                    && Object.keys(variants).length >= configurableVariantIndex
+                ? variants[configurableVariantIndex] : '';
 
             return (
                 <>


### PR DESCRIPTION
This is a possible fix for issue where product variant at `configurableVariantIndex === 0` is displaying sku of a parent configurable product and not it's own.

Issue caused by the way Javascript handles Object and number 0 in a logical `&&`

This solution works both on configurable products with variants and on single product, but more explicit checks might be necessary.

Let me know if you want this fix improved