### PR TITLE
Fixed issue where menu and all cms blocks fail if one block is disabled

### DIFF
--- a/src/app/store/CmsBlocksAndSlider/CmsBlocksAndSlider.reducer.js
+++ b/src/app/store/CmsBlocksAndSlider/CmsBlocksAndSlider.reducer.js
@@ -23,7 +23,13 @@ const CmsBlocksAndSliderReducer = (state = initialState, action) => {
     switch (action.type) {
     case UPDATE_CMS_BLOCKS:
         const { blocks: { items: blockItems } } = action;
-        const items = blockItems.reduce((o, item) => ({ ...o, [item.identifier]: item }), {});
+        const items = blockItems.reduce((o, item) => {
+            if (item) {
+                return { ...o, [item.identifier]: item };
+            }
+
+            return { ...o };
+        }, {});
 
         if (state.blocks.items) {
             return {

--- a/src/app/util/Request/Request.js
+++ b/src/app/util/Request/Request.js
@@ -115,6 +115,7 @@ const postFetch = (graphQlURI, query, variables) => fetch(graphQlURI,
  */
 const checkForErrors = res => new Promise((resolve, reject) => {
     const { errors, data } = res;
+    // eslint-disable-next-line no-console
     if (errors) { console.error(errors); }
     return !data && errors ? reject(errors) : resolve(data);
 });

--- a/src/app/util/Request/Request.js
+++ b/src/app/util/Request/Request.js
@@ -106,13 +106,17 @@ const postFetch = (graphQlURI, query, variables) => fetch(graphQlURI,
     });
 
 /**
- * Checks for errors in response, if they exist, rejects promise
+ * Check for errors in response, but reject only if data does not exist and error is present.
+ * Due query batching it is possible that only one of many queries or resources within query returns error, it is better
+ * to log error and return remaining resources rather than fail whole query.
+ *
  * @param  {Object} res Response from GraphQL endpoint
  * @return {Promise<Object>} Handled GraphqlQL results promise
  */
 const checkForErrors = res => new Promise((resolve, reject) => {
     const { errors, data } = res;
-    return errors ? reject(errors) : resolve(data);
+    if (errors) { console.error(errors); }
+    return !data && errors ? reject(errors) : resolve(data);
 });
 
 /**


### PR DESCRIPTION
There is an issue where all resources from batched query fails if one of the requested cms blocks does not exist.
This issue limits such functionality as enable/disable cms block from BE without updating frontend.