### PR TITLE
removed magento 2 community dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "OSL-3.0"
     ],
     "require": {
-        "magento/product-community-edition": "2.3.1",
         "scandipwa/menu-organizer": "^1.0",
         "scandipwa/persisted-query": "^1.0",
         "scandipwa/slider-graphql": "^1.0",


### PR DESCRIPTION
This pull request means to remove dependency of magento-community-edition from scandibase repo. After removing the dependency from above package, here is the list from where magento 2 dependency should be removed as discussed with Scandi team in slack:

1. https://packagist.org/packages/scandipwa/persisted-query
2. https://packagist.org/packages/scandipwa/slider-graphql
3. https://packagist.org/packages/scandipwa/cms-graphql (this only listed magento module name, I guess leaving it as it is will not make any issue)
4. https://packagist.org/packages/scandipwa/catalog-graphql
5. https://packagist.org/packages/scandipwa/route717
6. https://packagist.org/packages/scandipwa/customer-graph-ql
7. https://packagist.org/packages/scandipwa/quote-graphql
8. https://packagist.org/packages/scandipwa/wishlist-graphql
9. https://packagist.org/packages/scandipwa/urlrewrite-graphql
10. https://packagist.org/packages/scandipwa/reviews-graphql

