### PR TITLE
Fix issue with special prices showing up if discount is not active yet

### DIFF
--- a/src/app/query/ProductList.query.js
+++ b/src/app/query/ProductList.query.js
@@ -487,6 +487,8 @@ class ProductListQuery {
             (new Field('short_description').addField('html')),
             'url_key',
             'special_price',
+            'special_from_date',
+            'special_to_date',
             'sku'
         ];
 


### PR DESCRIPTION
If we do not request special price dates then the minimalPrice/maximalPrice is calculated incorrectly. This results in items showing up with a discount on category/PDP pages when they should not have a discount applied.