### PR TITLE
Fixed duplicate product on PLP

### DIFF
--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -142,11 +142,11 @@ class CategoryPage extends PureComponent {
         const {
             category,
             requestPage,
-            isInfoLoading,
+            isPagesLoading,
             pageParams: { totalPages, currentPage }
         } = this.props;
 
-        if (isInfoLoading) return null;
+        if (isPagesLoading) return null;
 
         return (
             <CategoryPagination
@@ -210,7 +210,6 @@ CategoryPage.propTypes = {
         currentPage: PropTypes.number
     }).isRequired,
     getFilterUrl: PropTypes.func.isRequired,
-    isInfoLoading: PropTypes.bool.isRequired,
     isPagesLoading: PropTypes.bool.isRequired,
     onSortChange: PropTypes.func.isRequired,
     requestPage: PropTypes.func.isRequired,

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -221,12 +221,11 @@ export class CategoryPageContainer extends PureComponent {
     }
 
     _getPageParams() {
-        const { totalItems } = this.props;
+        const { totalItems, pages } = this.props;
         const { pageSize } = this.config;
-        const pageFromUrl = getQueryParam('page', location) || 1;
 
         const totalPages = Math.ceil(totalItems / pageSize);
-        const currentPage = parseInt(totalPages < pageFromUrl ? totalPages : pageFromUrl, 10);
+        const currentPage = Math.max(...Object.keys(pages));
 
         return { totalPages, currentPage };
     }


### PR DESCRIPTION
Fixes UX issue when next (ie 2nd) page with 1 product is considered as part of first one. This solution assumes that current page is maximal loaded page as pagination is located at pages bottom part.