### PR TITLE
fixed configurable product page crash in case any variant is null

### DIFF
--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -122,15 +122,16 @@ export class CartDispatcher {
             if (type_id === 'configurable') {
                 let configurableVariantIndex = 0;
 
-                const { product: variant } = variants.find(
-                    ({ product }, index) => {
+                const selectedVariant = Object.entries(variants).filter( ([index,{product}]) => {
+                    return product != undefined;
+                }).find(([index, { product }] , id) => {
                         const { sku: productSku } = product;
                         const isChosenProduct = productSku === sku;
-                        if (isChosenProduct) configurableVariantIndex = index;
+                        if (isChosenProduct) configurableVariantIndex = id;
                         return isChosenProduct;
                     }
                 );
-
+                const [index, {product: variant} ] = selectedVariant;
                 if (variant) {
                     const { id: variantId } = variant;
 

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -122,15 +122,17 @@ export class CartDispatcher {
             if (type_id === 'configurable') {
                 let configurableVariantIndex = 0;
 
-                const selectedVariant = variants
-                    .filter(({ product }) => product !== null)
-                    .find((variant, id) => {
-                        const { sku: productSku } = variant.product;
+                const { product: variant } = variants.find(
+                    ({ product }, index) => {
+                        if (product === null) return false;
+                        configurableVariantIndex++;
+                        const { sku: productSku } = product;
                         const isChosenProduct = productSku === sku;
-                        if (isChosenProduct) configurableVariantIndex = id;
+                        if (isChosenProduct) configurableVariantIndex = index;
                         return isChosenProduct;
-                    });
-                const { product: variant } = selectedVariant;
+                    }
+                );
+
                 if (variant) {
                     const { id: variantId } = variant;
 

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -123,12 +123,11 @@ export class CartDispatcher {
                 let configurableVariantIndex = 0;
 
                 const { product: variant } = variants.find(
-                    ({ product }, index) => {
+                    ({ product }) => {
                         if (product === null) return false;
-                        configurableVariantIndex++;
                         const { sku: productSku } = product;
                         const isChosenProduct = productSku === sku;
-                        if (isChosenProduct) configurableVariantIndex = index;
+                        if (!isChosenProduct) configurableVariantIndex++;
                         return isChosenProduct;
                     }
                 );

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -122,16 +122,15 @@ export class CartDispatcher {
             if (type_id === 'configurable') {
                 let configurableVariantIndex = 0;
 
-                const selectedVariant = Object.entries(variants).filter( ([index,{product}]) => {
-                    return product != undefined;
-                }).find(([index, { product }] , id) => {
-                        const { sku: productSku } = product;
+                const selectedVariant = variants
+                    .filter(({ product }) => product !== null)
+                    .find((variant, id) => {
+                        const { sku: productSku } = variant.product;
                         const isChosenProduct = productSku === sku;
                         if (isChosenProduct) configurableVariantIndex = id;
                         return isChosenProduct;
-                    }
-                );
-                const [index, {product: variant} ] = selectedVariant;
+                    });
+                const { product: variant } = selectedVariant;
                 if (variant) {
                     const { id: variantId } = variant;
 

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -56,15 +56,15 @@ const getIndexedConfigurableOptions = (configurableOptions, indexedAttributes) =
     }, {})
 );
 
-const getIndexedVariants = variants => Object.entries(variants).filter( ([index,{product}]) => {
-    return product != undefined;
-}).map(([index,{ product }]) => {
-    const { attributes } = product;
-    return {
-        ...product,
-        attributes: getIndexedAttributes(attributes)
-    };
-});
+const getIndexedVariants = variants => variants
+    .filter(({ product }) => product !== null)
+    .map(({ product }) => {
+        const { attributes } = product;
+        return {
+            ...product,
+            attributes: getIndexedAttributes(attributes)
+        };
+    });
 
 /**
  * Get product variant index by options
@@ -72,16 +72,12 @@ const getIndexedVariants = variants => Object.entries(variants).filter( ([index,
  * @param {{ attribute_code: string }[]} options
  * @returns {number}
  */
-export const getVariantIndex = (variants, options) => Object.entries(variants)
-    .filter( ([index,variant]) => {
-        return variant != undefined;
-    }).findIndex(([index,variant]) => checkEveryOption(variant.attributes, options));
+export const getVariantIndex = (variants, options) => variants
+    .findIndex(variant => checkEveryOption(variant.attributes, options));
 
 export const getVariantsIndexes = (variants, options) => Object.entries(variants)
-    .filter( ([index,variant]) => {
-        return variant != undefined;
-    }).reduce((indexes, [index, variant]) => {
-        if (checkEveryOption(variant.attributes, options)) indexes.push(+index);
+    .reduce((indexes, [index, variant]) => {
+        if (variant !== null && checkEveryOption(variant.attributes, options)) indexes.push(+index);
         return indexes;
     }, []);
 

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -56,7 +56,9 @@ const getIndexedConfigurableOptions = (configurableOptions, indexedAttributes) =
     }, {})
 );
 
-const getIndexedVariants = variants => variants.map(({ product }) => {
+const getIndexedVariants = variants => Object.entries(variants).filter( ([index,{product}]) => {
+    return product != undefined;
+}).map(([index,{ product }]) => {
     const { attributes } = product;
     return {
         ...product,
@@ -70,11 +72,15 @@ const getIndexedVariants = variants => variants.map(({ product }) => {
  * @param {{ attribute_code: string }[]} options
  * @returns {number}
  */
-export const getVariantIndex = (variants, options) => variants
-    .findIndex(variant => checkEveryOption(variant.attributes, options));
+export const getVariantIndex = (variants, options) => Object.entries(variants)
+    .filter( ([index,variant]) => {
+        return variant != undefined;
+    }).findIndex(([index,variant]) => checkEveryOption(variant.attributes, options));
 
 export const getVariantsIndexes = (variants, options) => Object.entries(variants)
-    .reduce((indexes, [index, variant]) => {
+    .filter( ([index,variant]) => {
+        return variant != undefined;
+    }).reduce((indexes, [index, variant]) => {
         if (checkEveryOption(variant.attributes, options)) indexes.push(+index);
         return indexes;
     }, []);

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -57,14 +57,17 @@ const getIndexedConfigurableOptions = (configurableOptions, indexedAttributes) =
 );
 
 const getIndexedVariants = variants => variants
-    .filter(({ product }) => product !== null)
-    .map(({ product }) => {
-        const { attributes } = product;
-        return {
-            ...product,
-            attributes: getIndexedAttributes(attributes)
-        };
-    });
+    .reduce((filteredVariants, { product }) => {
+        if (product !== null) {
+            const { attributes } = product;
+            const filteredVariant = {
+                ...product,
+                attributes: getIndexedAttributes(attributes)
+            };
+            filteredVariants.push(filteredVariant);
+        }
+        return filteredVariants;
+    }, []);
 
 /**
  * Get product variant index by options


### PR DESCRIPTION
- Fix of category page crash if one of the variants of product(s) in listing was/were null
- Fix of product page if one of the variants of product was null
- Fixed Irregular behaviour of add to cart functionality for selected variant (in case if one or more variants were disabled from backend or were out of stock)