### PR TITLE
Availability of Configurable Product Attribute is checked based on variants

### DIFF
--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -39,7 +39,7 @@ export default class ProductActions extends PureComponent {
         setQuantity: PropTypes.func.isRequired,
         updateConfigurableVariant: PropTypes.func.isRequired,
         parameters: PropTypes.objectOf(PropTypes.string).isRequired,
-        isConfigurableAttributeAvailable: PropTypes.func.isRequired
+        getIsConfigurableAttributeAvailable: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -77,7 +77,7 @@ export default class ProductActions extends PureComponent {
             parameters,
             areDetailsLoaded,
             product: { configurable_options, type_id },
-            isConfigurableAttributeAvailable
+            getIsConfigurableAttributeAvailable
         } = this.props;
 
         if (type_id !== 'configurable') return null;
@@ -92,7 +92,7 @@ export default class ProductActions extends PureComponent {
               parameters={ parameters }
               updateConfigurableVariant={ updateConfigurableVariant }
               configurable_options={ configurable_options }
-              isAvailable={ isConfigurableAttributeAvailable }
+              getIsAvailable={ getIsConfigurableAttributeAvailable }
               isContentExpanded
             />
         );

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -75,7 +75,7 @@ export default class ProductActions extends PureComponent {
             updateConfigurableVariant,
             parameters,
             areDetailsLoaded,
-            product: { configurable_options, type_id }
+            product: { configurable_options, type_id, variants }
         } = this.props;
 
         if (type_id !== 'configurable') return null;
@@ -90,6 +90,7 @@ export default class ProductActions extends PureComponent {
               parameters={ parameters }
               updateConfigurableVariant={ updateConfigurableVariant }
               configurable_options={ configurable_options }
+              variants={ variants }
               isContentExpanded
             />
         );

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -38,7 +38,8 @@ export default class ProductActions extends PureComponent {
         getLink: PropTypes.func.isRequired,
         setQuantity: PropTypes.func.isRequired,
         updateConfigurableVariant: PropTypes.func.isRequired,
-        parameters: PropTypes.objectOf(PropTypes.string).isRequired
+        parameters: PropTypes.objectOf(PropTypes.string).isRequired,
+        isConfigurableAttributeAvailable: PropTypes.func.isRequired
     };
 
     static defaultProps = {
@@ -75,7 +76,8 @@ export default class ProductActions extends PureComponent {
             updateConfigurableVariant,
             parameters,
             areDetailsLoaded,
-            product: { configurable_options, type_id, variants }
+            product: { configurable_options, type_id },
+            isConfigurableAttributeAvailable
         } = this.props;
 
         if (type_id !== 'configurable') return null;
@@ -90,7 +92,7 @@ export default class ProductActions extends PureComponent {
               parameters={ parameters }
               updateConfigurableVariant={ updateConfigurableVariant }
               configurable_options={ configurable_options }
-              variants={ variants }
+              isAvailable={ isConfigurableAttributeAvailable }
               isContentExpanded
             />
         );

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -37,7 +37,7 @@ export default class ProductActions extends PureComponent {
         areDetailsLoaded: PropTypes.bool.isRequired,
         getLink: PropTypes.func.isRequired,
         setQuantity: PropTypes.func.isRequired,
-        updateUrl: PropTypes.func.isRequired,
+        updateConfigurableVariant: PropTypes.func.isRequired,
         parameters: PropTypes.objectOf(PropTypes.string).isRequired
     };
 
@@ -72,7 +72,7 @@ export default class ProductActions extends PureComponent {
     renderConfigurableAttributes() {
         const {
             getLink,
-            updateUrl,
+            updateConfigurableVariant,
             parameters,
             areDetailsLoaded,
             product: { configurable_options, type_id }
@@ -88,7 +88,7 @@ export default class ProductActions extends PureComponent {
               isReady={ areDetailsLoaded }
               getLink={ getLink }
               parameters={ parameters }
-              updateConfigurableVariant={ updateUrl }
+              updateConfigurableVariant={ updateConfigurableVariant }
               configurable_options={ configurable_options }
               isContentExpanded
             />

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -92,7 +92,7 @@ export default class ProductActions extends PureComponent {
               parameters={ parameters }
               updateConfigurableVariant={ updateConfigurableVariant }
               configurable_options={ configurable_options }
-              getIsAvailable={ getIsConfigurableAttributeAvailable }
+              getIsConfigurableAttributeAvailable={ getIsConfigurableAttributeAvailable }
               isContentExpanded
             />
         );

--- a/src/app/component/ProductActions/ProductActions.container.js
+++ b/src/app/component/ProductActions/ProductActions.container.js
@@ -33,7 +33,7 @@ export class ProductActionsContainer extends PureComponent {
         showOnlyIfLoaded: this.showOnlyIfLoaded.bind(this),
         getIsOptionInCurrentVariant: this.getIsOptionInCurrentVariant.bind(this),
         setQuantity: this.setQuantity.bind(this),
-        isConfigurableAttributeAvailable: this.isConfigurableAttributeAvailable.bind(this)
+        getIsConfigurableAttributeAvailable: this.getIsConfigurableAttributeAvailable.bind(this)
     };
 
     setQuantity(value) {
@@ -47,25 +47,8 @@ export class ProductActionsContainer extends PureComponent {
         return variants[configurableVariantIndex].product[attribute] === value;
     }
 
-    showOnlyIfLoaded(expression, content, placeholder = content) {
-        const { areDetailsLoaded } = this.props;
-
-        if (!areDetailsLoaded) return placeholder;
-        if (areDetailsLoaded && !expression) return null;
-        return content;
-    }
-
-    /**
-     * Checks whether provided attribute is available
-     *
-     * @param {{ attribute_code: String, attribute_value: String }} { attribute_code, attribute_value }
-     * @returns {bool}
-     * @memberof ProductConfigurableAttributes
-     */
-    isConfigurableAttributeAvailable({ attribute_code, attribute_value }) {
+    getIsConfigurableAttributeAvailable({ attribute_code, attribute_value }) {
         const { parameters, product: { variants } } = this.props;
-
-        if (!variants.length) return true;
 
         const isAttributeSelected = Object.hasOwnProperty.call(parameters, attribute_code);
 
@@ -85,6 +68,14 @@ export class ProductActionsContainer extends PureComponent {
                 && attributes[attribute_code].attribute_value === attribute_value
                 // Variant must have all currently selected attributes
                 && selectedAttributes.every(([key, value]) => attributes[key].attribute_value === value));
+    }
+
+    showOnlyIfLoaded(expression, content, placeholder = content) {
+        const { areDetailsLoaded } = this.props;
+
+        if (!areDetailsLoaded) return placeholder;
+        if (areDetailsLoaded && !expression) return null;
+        return content;
     }
 
     render() {

--- a/src/app/component/ProductActions/ProductActions.container.js
+++ b/src/app/component/ProductActions/ProductActions.container.js
@@ -23,7 +23,8 @@ export class ProductActionsContainer extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,
         configurableVariantIndex: PropTypes.number.isRequired,
-        areDetailsLoaded: PropTypes.bool.isRequired
+        areDetailsLoaded: PropTypes.bool.isRequired,
+        parameters: PropTypes.objectOf(PropTypes.string).isRequired
     };
 
     state = { quantity: 1 };
@@ -31,7 +32,8 @@ export class ProductActionsContainer extends PureComponent {
     containerFunctions = {
         showOnlyIfLoaded: this.showOnlyIfLoaded.bind(this),
         getIsOptionInCurrentVariant: this.getIsOptionInCurrentVariant.bind(this),
-        setQuantity: this.setQuantity.bind(this)
+        setQuantity: this.setQuantity.bind(this),
+        isConfigurableAttributeAvailable: this.isConfigurableAttributeAvailable.bind(this)
     };
 
     setQuantity(value) {
@@ -51,6 +53,38 @@ export class ProductActionsContainer extends PureComponent {
         if (!areDetailsLoaded) return placeholder;
         if (areDetailsLoaded && !expression) return null;
         return content;
+    }
+
+    /**
+     * Checks whether provided attribute is available
+     *
+     * @param {{ attribute_code: String, attribute_value: String }} { attribute_code, attribute_value }
+     * @returns {bool}
+     * @memberof ProductConfigurableAttributes
+     */
+    isConfigurableAttributeAvailable({ attribute_code, attribute_value }) {
+        const { parameters, product: { variants } } = this.props;
+
+        if (!variants.length) return true;
+
+        const isAttributeSelected = Object.hasOwnProperty.call(parameters, attribute_code);
+
+        // If value matches current attribute_value, option should be enabled
+        if (isAttributeSelected && parameters[attribute_code] === attribute_value) return true;
+
+        const parameterPairs = Object.entries(parameters);
+
+        const selectedAttributes = isAttributeSelected
+            // Need to exclude itself, otherwise different attribute_values of the same attribute_code will always be disabled
+            ? parameterPairs.filter(([key]) => key !== attribute_code)
+            : parameterPairs;
+
+        return variants
+            .some(({ stock_status, attributes }) => stock_status === 'IN_STOCK'
+                // Variant must have currently checked attribute_code and attribute_value
+                && attributes[attribute_code].attribute_value === attribute_value
+                // Variant must have all currently selected attributes
+                && selectedAttributes.every(([key, value]) => attributes[key].attribute_value === value));
     }
 
     render() {

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -23,7 +23,7 @@ export default class ProductAttributeValue extends Component {
         onClick: PropTypes.func.isRequired,
         attribute: AttributeType.isRequired,
         isSelected: PropTypes.bool,
-        isEnabled: PropTypes.bool.isRequired,
+        isAvailable: PropTypes.bool.isRequired,
         mix: MixType
     };
 
@@ -181,7 +181,7 @@ export default class ProductAttributeValue extends Component {
         const {
             getLink,
             attribute,
-            isEnabled,
+            isAvailable,
             attribute: { attribute_code, attribute_value },
             mix
         } = this.props;
@@ -189,7 +189,7 @@ export default class ProductAttributeValue extends Component {
         if (attribute_code && !attribute_value) return null;
 
         const href = getLink(attribute);
-        const isNotAvailable = !isEnabled;
+        const isNotAvailable = !isAvailable;
 
         return (
             <a

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -23,6 +23,7 @@ export default class ProductAttributeValue extends Component {
         onClick: PropTypes.func.isRequired,
         attribute: AttributeType.isRequired,
         isSelected: PropTypes.bool,
+        isEnabled: PropTypes.bool.isRequired,
         mix: MixType
     };
 
@@ -180,6 +181,7 @@ export default class ProductAttributeValue extends Component {
         const {
             getLink,
             attribute,
+            isEnabled,
             attribute: { attribute_code, attribute_value },
             mix
         } = this.props;
@@ -187,12 +189,15 @@ export default class ProductAttributeValue extends Component {
         if (attribute_code && !attribute_value) return null;
 
         const href = getLink(attribute);
+        const isNotAvailable = !isEnabled;
 
         return (
             <a
               href={ href }
               block="ProductAttributeValue"
+              mods={ { isNotAvailable } }
               onClick={ this.clickHandler }
+              aria-hidden={ isNotAvailable }
               mix={ mix }
             >
                 { this.renderAttributeByType() }

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -189,6 +189,7 @@ export default class ProductAttributeValue extends Component {
         if (attribute_code && !attribute_value) return null;
 
         const href = getLink(attribute);
+        // Invert to apply css rule without using not()
         const isNotAvailable = !isAvailable;
 
         return (

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -108,4 +108,9 @@
             --option-text-color: var(--color-primary-base);
         }
     }
+
+    &_isNotAvailable {
+        opacity: .25;
+        pointer-events: none;
+    }
 }

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -97,7 +97,9 @@ export default class ProductConfigurableAttributes extends Component {
         const { parameters, variants } = this.props;
 
         const isAvailable = selectedOptions => variants
-            .some(({ attributes }) => {
+            .some(({ stock_status, attributes }) => {
+                if (stock_status !== 'IN_STOCK') return false;
+
                 // Check if variant has current attribute_code and attribute_value
                 const variantHasCurrentOption = Object.hasOwnProperty.call(attributes, attribute_code)
                     && attributes[attribute_code].attribute_value === attribute_value;

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -27,7 +27,7 @@ export default class ProductConfigurableAttributes extends Component {
         updateConfigurableVariant: PropTypes.func.isRequired,
         isReady: PropTypes.bool,
         mix: MixType,
-        getIsAvailable: PropTypes.func
+        getIsConfigurableAttributeAvailable: PropTypes.func
     };
 
     static defaultProps = {
@@ -36,7 +36,7 @@ export default class ProductConfigurableAttributes extends Component {
         // eslint-disable-next-line no-magic-numbers
         numberOfPlaceholders: [6, 10, 7],
         isContentExpanded: false,
-        getIsAvailable: () => true
+        getIsConfigurableAttributeAvailable: () => true
     };
 
     /**
@@ -87,7 +87,7 @@ export default class ProductConfigurableAttributes extends Component {
     }
 
     renderConfigurableAttributeValue(attribute) {
-        const { getIsAvailable } = this.props;
+        const { getIsConfigurableAttributeAvailable } = this.props;
         const { attribute_value } = attribute;
 
         return (
@@ -95,7 +95,7 @@ export default class ProductConfigurableAttributes extends Component {
               key={ attribute_value }
               attribute={ attribute }
               isSelected={ this.isSelected(attribute) }
-              isAvailable={ getIsAvailable(attribute) }
+              isAvailable={ getIsConfigurableAttributeAvailable(attribute) }
               onClick={ this.handleOptionClick }
               getLink={ this.getLink }
             />

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -26,7 +26,8 @@ export default class ProductConfigurableAttributes extends Component {
         parameters: PropTypes.shape({}).isRequired,
         updateConfigurableVariant: PropTypes.func.isRequired,
         isReady: PropTypes.bool,
-        mix: MixType
+        mix: MixType,
+        isAvailable: PropTypes.func
     };
 
     static defaultProps = {
@@ -34,7 +35,8 @@ export default class ProductConfigurableAttributes extends Component {
         mix: {},
         // eslint-disable-next-line no-magic-numbers
         numberOfPlaceholders: [6, 10, 7],
-        isContentExpanded: false
+        isContentExpanded: false,
+        isAvailable: () => true
     };
 
     /**
@@ -84,37 +86,8 @@ export default class ProductConfigurableAttributes extends Component {
         return parameter === attribute_value;
     }
 
-    /**
-     * Checks whether provided attribute is available
-     *
-     * @param {{ attribute_code: String, attribute_value: String }} { attribute_code, attribute_value }
-     * @returns {bool}
-     * @memberof ProductConfigurableAttributes
-     */
-    isAvailable({ attribute_code, attribute_value }) {
-        const { parameters, variants } = this.props;
-
-        const isAttributeSelected = Object.hasOwnProperty.call(parameters, attribute_code);
-
-        // If value matches current attribute_value, option should be enabled
-        if (isAttributeSelected && parameters[attribute_code] === attribute_value) return true;
-
-        const parameterPairs = Object.entries(parameters);
-
-        const selectedAttributes = isAttributeSelected
-            // Need to exclude itself, otherwise different attribute_values of the same attribute_code will always be disabled
-            ? parameterPairs.filter(([key]) => key !== attribute_code)
-            : parameterPairs;
-
-        return variants
-            .some(({ stock_status, attributes }) => stock_status === 'IN_STOCK'
-                // Variant must have currently checked attribute_code and attribute_value
-                && attributes[attribute_code].attribute_value === attribute_value
-                // Variant must have all currently selected attributes
-                && selectedAttributes.every(([key, value]) => attributes[key].attribute_value === value));
-    }
-
     renderConfigurableAttributeValue(attribute) {
+        const { isAvailable } = this.props;
         const { attribute_value } = attribute;
 
         return (
@@ -122,7 +95,7 @@ export default class ProductConfigurableAttributes extends Component {
               key={ attribute_value }
               attribute={ attribute }
               isSelected={ this.isSelected(attribute) }
-              isAvailable={ this.isAvailable(attribute) }
+              isAvailable={ isAvailable(attribute) }
               onClick={ this.handleOptionClick }
               getLink={ this.getLink }
             />

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -26,8 +26,7 @@ export default class ProductConfigurableAttributes extends Component {
         parameters: PropTypes.shape({}).isRequired,
         updateConfigurableVariant: PropTypes.func.isRequired,
         isReady: PropTypes.bool,
-        mix: MixType,
-        variants: PropTypes.arrayOf(AttributeType)
+        mix: MixType
     };
 
     static defaultProps = {
@@ -35,8 +34,7 @@ export default class ProductConfigurableAttributes extends Component {
         mix: {},
         // eslint-disable-next-line no-magic-numbers
         numberOfPlaceholders: [6, 10, 7],
-        isContentExpanded: false,
-        variants: []
+        isContentExpanded: false
     };
 
     /**

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -93,10 +93,10 @@ export default class ProductConfigurableAttributes extends Component {
      * @returns {bool}
      * @memberof ProductConfigurableAttributes
      */
-    isEnabled({ attribute_code, attribute_value }) {
+    isAvailable({ attribute_code, attribute_value }) {
         const { parameters, variants } = this.props;
 
-        const isEnabled = selectedOptions => variants
+        const isAvailable = selectedOptions => variants
             .some(({ attributes }) => {
                 // Check if variant has current attribute_code and attribute_value
                 const variantHasCurrentOption = Object.hasOwnProperty.call(attributes, attribute_code)
@@ -120,10 +120,10 @@ export default class ProductConfigurableAttributes extends Component {
                 .entries(parameters)
                 .filter(([key]) => key !== attribute_code);
 
-            return isEnabled(options);
+            return isAvailable(options);
         }
 
-        return isEnabled(Object.entries(parameters));
+        return isAvailable(Object.entries(parameters));
     }
 
     renderConfigurableAttributeValue(attribute) {
@@ -134,7 +134,7 @@ export default class ProductConfigurableAttributes extends Component {
               key={ attribute_value }
               attribute={ attribute }
               isSelected={ this.isSelected(attribute) }
-              isEnabled={ this.isEnabled(attribute) }
+              isAvailable={ this.isAvailable(attribute) }
               onClick={ this.handleOptionClick }
               getLink={ this.getLink }
             />

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -27,7 +27,7 @@ export default class ProductConfigurableAttributes extends Component {
         updateConfigurableVariant: PropTypes.func.isRequired,
         isReady: PropTypes.bool,
         mix: MixType,
-        isAvailable: PropTypes.func
+        getIsAvailable: PropTypes.func
     };
 
     static defaultProps = {
@@ -36,7 +36,7 @@ export default class ProductConfigurableAttributes extends Component {
         // eslint-disable-next-line no-magic-numbers
         numberOfPlaceholders: [6, 10, 7],
         isContentExpanded: false,
-        isAvailable: () => true
+        getIsAvailable: () => true
     };
 
     /**
@@ -87,7 +87,7 @@ export default class ProductConfigurableAttributes extends Component {
     }
 
     renderConfigurableAttributeValue(attribute) {
-        const { isAvailable } = this.props;
+        const { getIsAvailable } = this.props;
         const { attribute_value } = attribute;
 
         return (
@@ -95,7 +95,7 @@ export default class ProductConfigurableAttributes extends Component {
               key={ attribute_value }
               attribute={ attribute }
               isSelected={ this.isSelected(attribute) }
-              isAvailable={ isAvailable(attribute) }
+              isAvailable={ getIsAvailable(attribute) }
               onClick={ this.handleOptionClick }
               getLink={ this.getLink }
             />

--- a/src/app/route/ProductPage/ProductPage.component.js
+++ b/src/app/route/ProductPage/ProductPage.component.js
@@ -27,7 +27,7 @@ export default class ProductPage extends Component {
         productOrVariant: ProductType.isRequired,
         getLink: PropTypes.func.isRequired,
         parameters: PropTypes.objectOf(PropTypes.string).isRequired,
-        updateUrl: PropTypes.func.isRequired,
+        updateConfigurableVariant: PropTypes.func.isRequired,
         dataSource: ProductType.isRequired,
         areDetailsLoaded: PropTypes.bool.isRequired
     };
@@ -38,7 +38,7 @@ export default class ProductPage extends Component {
             parameters,
             getLink,
             dataSource,
-            updateUrl,
+            updateConfigurableVariant,
             productOrVariant,
             areDetailsLoaded
         } = this.props;
@@ -50,7 +50,7 @@ export default class ProductPage extends Component {
                 />
                 <ProductActions
                   getLink={ getLink }
-                  updateUrl={ updateUrl }
+                  updateConfigurableVariant={ updateConfigurableVariant }
                   product={ dataSource }
                   parameters={ parameters }
                   areDetailsLoaded={ areDetailsLoaded }

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -88,10 +88,13 @@ export const getIndexedProduct = (product) => {
 
     const attributes = getIndexedAttributes(initialAttributes);
 
+    // If simple product is disabled, variant is still present, but its value is null
+    const enabledInitialVariants = initialVariants.filter(({ product }) => product);
+
     return {
         ...product,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
-        variants: getIndexedVariants(initialVariants),
+        variants: getIndexedVariants(enabledInitialVariants),
         attributes
     };
 };

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -88,13 +88,10 @@ export const getIndexedProduct = (product) => {
 
     const attributes = getIndexedAttributes(initialAttributes);
 
-    // If simple product is disabled, variant is still present, but its value is null
-    const enabledInitialVariants = initialVariants.filter(({ product }) => product);
-
     return {
         ...product,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
-        variants: getIndexedVariants(enabledInitialVariants),
+        variants: getIndexedVariants(initialVariants),
         attributes
     };
 };

--- a/src/app/util/Url/Url.js
+++ b/src/app/util/Url/Url.js
@@ -36,8 +36,7 @@ const removeQueryParamWithoutHistory = (name, history, location) => {
 
     const params = new URLSearchParams(search);
     params.delete(name);
-    const a = decodeURIComponent(`${ pathname }?${ params }`);
-    history.replace(a);
+    history.replace(decodeURIComponent(`${ pathname }?${ params }`));
 };
 
 /**

--- a/src/app/util/Url/Url.js
+++ b/src/app/util/Url/Url.js
@@ -28,6 +28,19 @@ const updateQueryParamWithoutHistory = (name, value, history, location) => {
 };
 
 /**
+ * Remove query param without adding to history
+ * @param {String} name
+ */
+const removeQueryParamWithoutHistory = (name, history, location) => {
+    const { search, pathname } = location;
+
+    const params = new URLSearchParams(search);
+    params.delete(name);
+    const a = decodeURIComponent(`${ pathname }?${ params }`);
+    history.replace(a);
+};
+
+/**
  * Get query param from url
  * @param {Object} match match object from react-router
  * @param {Object} location location object from react-router
@@ -187,6 +200,7 @@ export {
     setQueryParams,
     clearQueriesFromUrl,
     updateQueryParamWithoutHistory,
+    removeQueryParamWithoutHistory,
     convertQueryStringToKeyValuePairs,
     convertKeyValueObjectToQueryString
 };


### PR DESCRIPTION
Added ability to deselect value of Product Configurable Attribute.
Product Configurable Attribute is grayed out if there is no matching variant or if it is out of stock.

Depends on https://github.com/scandipwa/catalog-graphql/pull/15