### PR TITLE
Shipping address is not requested if all products in cart are virtual during checkout

### DIFF
--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -427,7 +427,7 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
         const { street, shippingAddress: { email: shippingEmail } } = this.state;
 
         // Shipping step is skipped if all products in cart are virtual
-        // This means tha email is not provided and we need to display the field
+        // This means that email is not provided and we must request it
         return (
             <>
                 { this.renderField(FIRSTNAME_FIELD_ID) }

--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -193,7 +193,7 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
             billing_address: correctAddress
         };
 
-        this.setState({ loadingPaymentInformationSave: true, finishedLoading: false });
+        this.setState({ loadingPaymentInformationSave: true });
 
         savePaymentInformationAndPlaceOrder(paymentInformation);
     };

--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -28,6 +28,7 @@ export const CITY_FIELD_ID = 'city';
 export const REGION_FIELD_ID = 'region';
 export const ZIP_FIELD_ID = 'postcode';
 export const PHONE_FIELD_ID = 'telephone';
+export const EMAIL_FIELD_ID = 'email';
 export const COUNTRY_FIELD_ID = 'country_id';
 export const DEFAULT_COUNTRY = 'US';
 export const DEFAULT_REGION = { region_code: 'AL', region: 'Alabama', region_id: 1 };
@@ -149,6 +150,10 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
             [PHONE_FIELD_ID]: {
                 label: __('Phone Number'),
                 validation: ['telephone']
+            },
+            [EMAIL_FIELD_ID]: {
+                label: __('Email Address'),
+                validation: ['notEmpty', 'email']
             }
         };
 
@@ -419,7 +424,7 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
     }
 
     renderNewAddress() {
-        const { street } = this.state;
+        const { street, shippingAddress: { email: shippingEmail } } = this.state;
 
         return (
             <>
@@ -432,6 +437,10 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
                 { this.renderField(ZIP_FIELD_ID) }
                 { this.renderCountrySelect() }
                 { this.renderField(PHONE_FIELD_ID) }
+                { (shippingEmail
+                    ? null
+                    : this.renderField(EMAIL_FIELD_ID)
+                ) }
             </>
         );
     }

--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -426,6 +426,8 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
     renderNewAddress() {
         const { street, shippingAddress: { email: shippingEmail } } = this.state;
 
+        // Shipping step is skipped if all products in cart are virtual
+        // This means tha email is not provided and we need to display the field
         return (
             <>
                 { this.renderField(FIRSTNAME_FIELD_ID) }

--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -74,8 +74,7 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
 
         const {
             shippingAddress,
-            billingAddress,
-            paymentMethods
+            billingAddress
         } = props;
 
         const { street } = billingAddress;
@@ -88,7 +87,6 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
             billingIsSame: false,
             selectedCountryIndex: null,
             country_id: null,
-            paymentMethods,
             activePaymentMethod: {},
             loadingPaymentInformationSave: false,
             defaultBillingAddress: false,
@@ -454,9 +452,8 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
     }
 
     render() {
-        const { finishedLoading } = this.props;
+        const { finishedLoading, paymentMethods } = this.props;
         const {
-            paymentMethods,
             billingIsSame,
             activePaymentMethod,
             shippingAddress,

--- a/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
+++ b/src/app/component/CheckoutPreviewAndPaymentsStep/CheckoutPreviewAndPaymentsStep.component.js
@@ -469,7 +469,7 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
               onSubmitSuccess={ this.onFormSuccess }
               key="review_and_payment_step"
             >
-                <Loader isLoading={ !finishedLoading || loadingPaymentInformationSave } />
+                <Loader isLoading={ loadingPaymentInformationSave } />
 
                 <fieldset>
                     <legend block="CheckoutPage" elem="Heading" mods={ { hasDivider: true } }>
@@ -493,10 +493,14 @@ export default class CheckoutPreviewAndPaymentsStep extends PureComponent {
                     { renderFunction() }
                 </fieldset>
 
-                <CheckoutPaymentMethods
-                  paymentMethods={ paymentMethods }
-                  onSelectPaymentMethod={ this.handleSelectPaymentMethod }
-                />
+                <div>
+                    <Loader isLoading={ !finishedLoading } />
+
+                    <CheckoutPaymentMethods
+                      paymentMethods={ paymentMethods }
+                      onSelectPaymentMethod={ this.handleSelectPaymentMethod }
+                    />
+                </div>
 
                 <button
                   type="submit"

--- a/src/app/query/Checkout.query.js
+++ b/src/app/query/Checkout.query.js
@@ -122,6 +122,7 @@ export class CheckoutQuery {
 
     _getTotalsFields() {
         return [
+            'items_qty',
             'subtotal',
             'tax_amount',
             'grand_total',

--- a/src/app/query/Checkout.query.js
+++ b/src/app/query/Checkout.query.js
@@ -43,6 +43,15 @@ export class CheckoutQuery {
         return mutation;
     }
 
+    getPaymentInformation(guestCartId) {
+        const query = new Field('getPaymentInformation')
+            .addFieldList(this._getPaymentInformationFields());
+
+        this._addGuestCartId(guestCartId, query);
+
+        return query;
+    }
+
     _addGuestCartId(guestCartId, mutation) {
         if (guestCartId && !isSignedIn()) mutation.addArgument('guestCartId', 'String!', guestCartId);
     }
@@ -60,6 +69,11 @@ export class CheckoutQuery {
         ];
     }
 
+    _getPaymentInformationFields() {
+        return [
+            this._getPaymentMethodsField()
+        ];
+    }
 
     _getEstimatedShippingFields() {
         return [

--- a/src/app/query/Checkout.query.js
+++ b/src/app/query/Checkout.query.js
@@ -71,7 +71,8 @@ export class CheckoutQuery {
 
     _getPaymentInformationFields() {
         return [
-            this._getPaymentMethodsField()
+            this._getPaymentMethodsField(),
+            this._getTotalsField()
         ];
     }
 

--- a/src/app/route/CheckoutPage/CheckoutPage.component.js
+++ b/src/app/route/CheckoutPage/CheckoutPage.component.js
@@ -357,7 +357,7 @@ export default class CheckoutPage extends Component {
                   elem="Heading"
                   mods={ { hasDivider: true } }
                 >
-                    Thank you for your purchase!
+                    { __('Thank you for your purchase!') }
                 </h1>
                 <p
                   block="CheckoutPage"

--- a/src/app/route/CheckoutPage/CheckoutPage.component.js
+++ b/src/app/route/CheckoutPage/CheckoutPage.component.js
@@ -86,7 +86,7 @@ export default class CheckoutPage extends Component {
             match
         } = props;
 
-        // If all products are virtual we go straight to billing address
+        // If all products are virtual shipping address is not required
         const checkoutStep = this.getAreAllProductsVirtual()
             ? CHECKOUT_STEP_REVIEW_AND_PAYMENTS
             : CHECKOUT_STEP_SHIPPING;
@@ -148,7 +148,7 @@ export default class CheckoutPage extends Component {
             this.getDefaultAddresses();
         }
 
-        //  Payment is retrieved after shipping address is set. We need to get payment methods explicitly, if shipping step was skipped
+        //  Payment is retrieved after shipping address is saved. We need to get payment methods explicitly, if shipping address step is skipped
         if (checkoutStep === CHECKOUT_STEP_REVIEW_AND_PAYMENTS) {
             this.updatePaymentMethods();
         }
@@ -216,9 +216,6 @@ export default class CheckoutPage extends Component {
             },
             (err) => {
                 showNotification('error', err[0].debugMessage);
-                this.setState({
-                    checkoutStep: CHECKOUT_STEP_SHIPPING
-                });
             }
         );
     }

--- a/src/app/route/CheckoutPage/CheckoutPage.component.js
+++ b/src/app/route/CheckoutPage/CheckoutPage.component.js
@@ -36,6 +36,7 @@ export default class CheckoutPage extends Component {
     static propTypes = {
         savePaymentInformationAndPlaceOrder: PropTypes.func.isRequired,
         saveAddressInformation: PropTypes.func.isRequired,
+        getPaymentInformation: PropTypes.func.isRequired,
         removeCartAndObtainNewGuest: PropTypes.func.isRequired,
         showNotification: PropTypes.func.isRequired,
         requestCustomerData: PropTypes.func.isRequired,

--- a/src/app/route/CheckoutPage/CheckoutPage.component.js
+++ b/src/app/route/CheckoutPage/CheckoutPage.component.js
@@ -98,6 +98,7 @@ export default class CheckoutPage extends Component {
             shippingAddress: {},
             billingAddress: {},
             addressesAreChecked: false,
+            isPaymentInformationLoaded: false,
             carrierCode: '',
             methodCode: '',
             paymentMethods: [],
@@ -201,7 +202,7 @@ export default class CheckoutPage extends Component {
         const { getPaymentInformation, showNotification } = this.props;
 
         this.setState({
-            addressesAreChecked: false
+            isPaymentInformationLoaded: false
         });
 
         getPaymentInformation().then(
@@ -210,7 +211,7 @@ export default class CheckoutPage extends Component {
                 this.setState({
                     paymentMethods: payment_methods,
                     paymentTotals: totals,
-                    addressesAreChecked: true
+                    isPaymentInformationLoaded: true
                 }, this.updateHeader);
             },
             (err) => {
@@ -247,7 +248,8 @@ export default class CheckoutPage extends Component {
             billingAddress: billing_address,
             carrierCode: shipping_carrier_code,
             methodCode: shipping_method_code,
-            addressesAreChecked: false
+            addressesAreChecked: false,
+            isPaymentInformationLoaded: false
         });
 
         return saveAddressInformation(addressInformation).then(
@@ -257,7 +259,8 @@ export default class CheckoutPage extends Component {
                     checkoutStep: CHECKOUT_STEP_REVIEW_AND_PAYMENTS,
                     paymentMethods: payment_methods,
                     paymentTotals: totals,
-                    addressesAreChecked: true
+                    addressesAreChecked: true,
+                    isPaymentInformationLoaded: true
                 }, this.updateHeader);
             },
             (err) => {
@@ -326,7 +329,7 @@ export default class CheckoutPage extends Component {
             shippingAddress,
             billingAddress,
             paymentMethods,
-            addressesAreChecked
+            isPaymentInformationLoaded
         } = this.state;
 
         return (
@@ -337,7 +340,7 @@ export default class CheckoutPage extends Component {
               savePaymentInformationAndPlaceOrder={ this.savePaymentInformationAndPlaceOrder }
               email={ email }
               isSignedIn={ isSignedIn }
-              finishedLoading={ addressesAreChecked }
+              finishedLoading={ isPaymentInformationLoaded }
               countryList={ countryList }
             />
         );

--- a/src/app/route/CheckoutPage/CheckoutPage.container.js
+++ b/src/app/route/CheckoutPage/CheckoutPage.container.js
@@ -12,7 +12,7 @@
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { GUEST_QUOTE_ID, CartDispatcher } from 'Store/Cart';
-import { fetchMutation } from 'Util/Request';
+import { fetchMutation, fetchQuery } from 'Util/Request';
 import CheckoutQuery from 'Query/Checkout.query';
 import BrowserDatabase from 'Util/BrowserDatabase';
 import { MyAccountDispatcher } from 'Store/MyAccount';
@@ -44,22 +44,32 @@ const mapDispatchToProps = dispatch => ({
 const MappedCheckoutPage = connect(mapStateToProps, mapDispatchToProps)(CheckoutPage);
 
 class CheckoutPageContainer extends PureComponent {
+    containerFunctions = {
+        saveAddressInformation: this.saveAddressInformation.bind(this),
+        savePaymentInformationAndPlaceOrder: this.savePaymentInformationAndPlaceOrder.bind(this),
+        getPaymentInformation: this.getPaymentInformation.bind(this)
+    };
+
     getGuestCartId = () => BrowserDatabase.getItem(GUEST_QUOTE_ID);
 
-    saveAddressInformation = addressInformation => fetchMutation(
-        CheckoutQuery.getSaveAddressInformation(addressInformation, this.getGuestCartId())
-    );
+    getPaymentInformation() {
+        return fetchQuery(CheckoutQuery.getPaymentInformation(this.getGuestCartId()));
+    }
 
-    savePaymentInformationAndPlaceOrder = paymentInformation => fetchMutation(
-        CheckoutQuery.getSavePaymentInformationAndPlaceOrder(paymentInformation, this.getGuestCartId())
-    );
+    saveAddressInformation(addressInformation) {
+        return fetchMutation(CheckoutQuery.getSaveAddressInformation(addressInformation, this.getGuestCartId()));
+    }
+
+    savePaymentInformationAndPlaceOrder(paymentInformation) {
+        return fetchMutation(CheckoutQuery
+            .getSavePaymentInformationAndPlaceOrder(paymentInformation, this.getGuestCartId()));
+    }
 
     render() {
         return (
             <MappedCheckoutPage
-              saveAddressInformation={ this.saveAddressInformation }
-              savePaymentInformationAndPlaceOrder={ this.savePaymentInformationAndPlaceOrder }
               { ...this.props }
+              { ...this.containerFunctions }
             />
         );
     }


### PR DESCRIPTION
If all products in cart are virtual, Shipping address step is skipped during checkout.
In this case e-mail address is requested in `CheckoutPreviewAndPaymentsStep` step.

Additional loader is used in `CheckoutPreviewAndPaymentsStep` component.
- First one covers whole form, when form is submitted.
- Second only covers "Payment method". This enables user to input Billing address data straight away, while payment methods are being loaded, if Shipping address step was skipped.

Fixed bug in `CheckoutOrderSummary` component when item count was displayed as 'unidentified Items In Cart'.

Depends on https://github.com/scandipwa/quote-graphql/pull/10