### PR TITLE
Display price of simple product in PDP

### DIFF
--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -60,7 +60,7 @@ export default class ProductActions extends PureComponent {
                     (
                         <>
                             <span block="ProductActions" elem="Sku" itemProp="sku">{ `SKU: ${ sku }` }</span>
-                            <span block="ProductActions" elem="Stock">In Stock</span>
+                            <span block="ProductActions" elem="Stock">{ __('In Stock') }</span>
                         </>
                     ),
                     <TextPlaceholder />

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -177,7 +177,7 @@ export default class ProductActions extends PureComponent {
     }
 
     renderPrice() {
-        const { product: { variants, price }, configurableVariantIndex } = this.props;
+        const { product: { price, variants }, configurableVariantIndex } = this.props;
 
         const productOrVariantPrice = configurableVariantIndex >= 0
             ? variants[configurableVariantIndex].price

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -177,11 +177,15 @@ export default class ProductActions extends PureComponent {
     }
 
     renderPrice() {
-        const { product: { price } } = this.props;
+        const { product: { variants, price }, configurableVariantIndex } = this.props;
+
+        const productOrVariantPrice = configurableVariantIndex > 0
+            ? variants[configurableVariantIndex].price
+            : price;
 
         return (
             <ProductPrice
-              price={ price }
+              price={ productOrVariantPrice }
               mix={ { block: 'ProductActions', elem: 'Price' } }
             />
         );

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -179,7 +179,7 @@ export default class ProductActions extends PureComponent {
     renderPrice() {
         const { product: { variants, price }, configurableVariantIndex } = this.props;
 
-        const productOrVariantPrice = configurableVariantIndex > 0
+        const productOrVariantPrice = configurableVariantIndex >= 0
             ? variants[configurableVariantIndex].price
             : price;
 


### PR DESCRIPTION
Display price of simple product, if variant is selected. Otherwise price of configurable parent is used.