### PR TITLE
Reverted null checks for variant

### DIFF
--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -147,11 +147,10 @@ export class CartDispatcher {
                 // eslint-disable-next-line fp/no-let
                 let configurableVariantIndex = 0;
 
-                variants.find(({ product }) => {
-                    if (product === null) return false;
+                variants.find(({ product }, index) => {
                     const { sku: productSku } = product;
                     const isChosenProduct = productSku === sku;
-                    if (!isChosenProduct) configurableVariantIndex++;
+                    if (isChosenProduct) configurableVariantIndex = index;
                     return isChosenProduct;
                 });
 

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -145,10 +145,7 @@ export class CartDispatcher {
 
             if (type_id === 'configurable') {
                 const configurableVariantIndex = variants
-                    .findIndex(({ product }) => {
-                        const { sku: productSku } = product;
-                        return productSku === sku;
-                    });
+                    .findIndex(({ product: { sku: productSku } }) => productSku === sku);
 
                 const { id: variantId } = variants[configurableVariantIndex].product;
 

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -144,29 +144,23 @@ export class CartDispatcher {
             } = cartProduct;
 
             if (type_id === 'configurable') {
-                // eslint-disable-next-line fp/no-let
-                let configurableVariantIndex = 0;
+                const configurableVariantIndex = variants
+                    .findIndex(({ product }) => {
+                        const { sku: productSku } = product;
+                        return productSku === sku;
+                    });
 
-                variants.find(({ product }, index) => {
-                    const { sku: productSku } = product;
-                    const isChosenProduct = productSku === sku;
-                    if (isChosenProduct) configurableVariantIndex = index;
-                    return isChosenProduct;
-                });
+                const { id: variantId } = variants[configurableVariantIndex].product;
 
-                if (configurableVariantIndex !== -1) {
-                    const { id: variantId } = variants[configurableVariantIndex].product;
-
-                    return {
-                        ...prev,
-                        [variantId]: {
-                            ...product,
-                            configurableVariantIndex,
-                            item_id,
-                            quantity
-                        }
-                    };
-                }
+                return {
+                    ...prev,
+                    [variantId]: {
+                        ...product,
+                        configurableVariantIndex,
+                        item_id,
+                        quantity
+                    }
+                };
             }
 
             return {

--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -147,17 +147,19 @@ export class CartDispatcher {
                 const configurableVariantIndex = variants
                     .findIndex(({ product: { sku: productSku } }) => productSku === sku);
 
-                const { id: variantId } = variants[configurableVariantIndex].product;
+                if (configurableVariantIndex !== -1) {
+                    const { id: variantId } = variants[configurableVariantIndex].product;
 
-                return {
-                    ...prev,
-                    [variantId]: {
-                        ...product,
-                        configurableVariantIndex,
-                        item_id,
-                        quantity
-                    }
-                };
+                    return {
+                        ...prev,
+                        [variantId]: {
+                            ...product,
+                            configurableVariantIndex,
+                            item_id,
+                            quantity
+                        }
+                    };
+                }
             }
 
             return {

--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -56,18 +56,13 @@ const getIndexedConfigurableOptions = (configurableOptions, indexedAttributes) =
     }, {})
 );
 
-const getIndexedVariants = variants => variants
-    .reduce((filteredVariants, { product }) => {
-        if (product !== null) {
-            const { attributes } = product;
-            const filteredVariant = {
-                ...product,
-                attributes: getIndexedAttributes(attributes)
-            };
-            filteredVariants.push(filteredVariant);
-        }
-        return filteredVariants;
-    }, []);
+const getIndexedVariants = variants => variants.map(({ product }) => {
+    const { attributes } = product;
+    return {
+        ...product,
+        attributes: getIndexedAttributes(attributes)
+    };
+});
 
 /**
  * Get product variant index by options
@@ -80,7 +75,7 @@ export const getVariantIndex = (variants, options) => variants
 
 export const getVariantsIndexes = (variants, options) => Object.entries(variants)
     .reduce((indexes, [index, variant]) => {
-        if (variant !== null && checkEveryOption(variant.attributes, options)) indexes.push(+index);
+        if (checkEveryOption(variant.attributes, options)) indexes.push(+index);
         return indexes;
     }, []);
 


### PR DESCRIPTION
Reverted changes from https://github.com/scandipwa/base-theme/pull/284
https://github.com/scandipwa/catalog-graphql/pull/16 filters out items that are out of stock on BE.
BE also handles cases when simple products are disabled. Looks like `product: null` situation should not happen anymore.

New version of [catalog-graphql](https://github.com/scandipwa/catalog-graphql)  is required.