### PR TITLE
Fixed issue when PDP was not update, when simple product is opened from CartOverlay

### DIFF
--- a/src/app/route/ProductPage/ProductPage.container.js
+++ b/src/app/route/ProductPage/ProductPage.container.js
@@ -94,18 +94,16 @@ export class ProductPageContainer extends PureComponent {
         return null;
     }
 
-    static getDerivedStateFromProps(props, state) {
-        const { id: stateId } = state;
+    static getDerivedStateFromProps(props) {
         const {
             product: {
-                id,
                 variants,
                 configurable_options
             },
             location: { search }
         } = props;
 
-        if (!(configurable_options && variants && id !== stateId)) return null;
+        if (!configurable_options && !variants) return null;
 
         const parameters = Object.entries(convertQueryStringToKeyValuePairs(search))
             .reduce((acc, [key, value]) => {
@@ -117,11 +115,11 @@ export class ProductPageContainer extends PureComponent {
             }, {});
 
         if (Object.keys(parameters).length !== Object.keys(configurable_options).length) {
-            return { id, parameters };
+            return { parameters };
         }
 
         const configurableVariantIndex = getVariantIndex(variants, parameters);
-        return { id, parameters, configurableVariantIndex };
+        return { parameters, configurableVariantIndex };
     }
 
     getLink(key, value) {


### PR DESCRIPTION
I think `id` comparison was used to improve performance, however it caused a following side effect:

Steps to reproduce:
1. Add simple product to Cart
2. Open PDP and select different attributes (size/color)
3. Open MiniCart
4. Click on CartItem added in first step

Result:
We stay on the same page, product selected in step 2 is displayed, but not the CarItem.
Refrehing the page updates the selection.

![Simple_product_cart_issue](https://user-images.githubusercontent.com/54805724/65858450-a4a9a600-e36e-11e9-89e5-3308e0febf31.gif)
