### PR TITLE
Fixed logic used for getting category info and products

### DIFF
--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -12,6 +12,7 @@ export class ProductListContainer extends PureComponent {
         location: PropTypes.shape({
             pathname: PropTypes.string.isRequired
         }).isRequired,
+        getIsNewCategory: PropTypes.func.isRequired,
         pages: PagesType.isRequired,
         pageSize: PropTypes.number,
         isLoading: PropTypes.bool.isRequired,
@@ -42,7 +43,7 @@ export class ProductListContainer extends PureComponent {
     };
 
     componentDidMount() {
-        const { pages } = this.props;
+        const { pages, getIsNewCategory } = this.props;
         const { pagesCount } = this.state;
         const pagesLength = Object.keys(pages).length;
 
@@ -50,7 +51,10 @@ export class ProductListContainer extends PureComponent {
             this.setState({ pagesCount: pagesLength });
         }
 
-        this.requestPage(this._getPageFromUrl());
+        // Is true when category is changed. This check prevents making new requests when navigating back to PLP from PDP
+        if (getIsNewCategory()) {
+            this.requestPage(this._getPageFromUrl());
+        }
     }
 
     componentDidUpdate(prevProps) {

--- a/src/app/component/ProductListWidget/ProductListWidget.container.js
+++ b/src/app/component/ProductListWidget/ProductListWidget.container.js
@@ -53,7 +53,8 @@ export class ProductListWidgetContainer extends PureComponent {
 
     containerFunctions = {
         requestProductList: this.requestProductList.bind(this),
-        updateLoadStatus: this.updateLoadStatus.bind(this)
+        updateLoadStatus: this.updateLoadStatus.bind(this),
+        getIsNewCategory: this.getIsNewCategory.bind(this)
     };
 
     onError = this.onError.bind(this);
@@ -66,6 +67,10 @@ export class ProductListWidgetContainer extends PureComponent {
         const { showNotification, updateNoMatch } = this.props;
         showNotification('error', 'Error fetching Product List!', error);
         updateNoMatch(true);
+    }
+
+    getIsNewCategory() {
+        return true;
     }
 
     appendPage(data) {

--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -27,6 +27,7 @@ export default class CategoryPage extends PureComponent {
         category: CategoryTreeType.isRequired,
         minPriceRange: PropTypes.number.isRequired,
         maxPriceRange: PropTypes.number.isRequired,
+        getIsNewCategory: PropTypes.func.isRequired,
         filters: PropTypes.objectOf(PropTypes.shape).isRequired,
         sortFields: PropTypes.shape({
             options: PropTypes.array
@@ -131,7 +132,8 @@ export default class CategoryPage extends PureComponent {
             filter,
             search,
             selectedSort,
-            selectedFilters
+            selectedFilters,
+            getIsNewCategory
         } = this.props;
 
         return (
@@ -140,6 +142,7 @@ export default class CategoryPage extends PureComponent {
               search={ search }
               sort={ selectedSort }
               selectedFilters={ selectedFilters }
+              getIsNewCategory={ getIsNewCategory }
             />
         );
     }

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -106,7 +106,8 @@ export class CategoryPageContainer extends PureComponent {
 
         // request data only if URL does not match loaded category
         if (this.isNewCategory()) {
-            this._requestCategoryWithPageList();
+            this._requestCategory();
+            this._requestCategoryProductsInfo();
             updateBreadcrumbs({});
         } else {
             this._onCategoryUpdate();
@@ -114,15 +115,20 @@ export class CategoryPageContainer extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const { category: { id }, categoryIds } = this.props;
+        const { category: { id }, categoryIds, location } = this.props;
         const { category: { id: prevId }, categoryIds: prevCategoryIds } = prevProps;
 
         // update breadcrumbs only if category has changed
         if (id !== prevId) this._onCategoryUpdate();
 
-        // update category only if route or search query has been changed
-        if (this.isNewCategory() || categoryIds !== prevCategoryIds) {
-            this._requestCategoryWithPageList();
+        // ComponentDidUpdate fires multiple times, to prevent getting same data we check that url has changed
+        if (this._urlHasChanged(location, prevProps) || categoryIds !== prevCategoryIds) {
+            // This prevents getting Category data, when sort or filter options have changed
+            if (this.isNewCategory()) {
+                this._requestCategory();
+            }
+
+            this._requestCategoryProductsInfo();
         }
     }
 
@@ -319,11 +325,6 @@ export class CategoryPageContainer extends PureComponent {
             isSearchPage,
             categoryIds
         });
-    }
-
-    _requestCategoryWithPageList() {
-        this._requestCategory();
-        this._requestCategoryProductsInfo();
     }
 
     _compareQueriesWithFilter(search, prevSearch, filter) {

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -121,7 +121,7 @@ export class CategoryPageContainer extends PureComponent {
         if (id !== prevId) this._onCategoryUpdate();
 
         // ComponentDidUpdate fires multiple times, to prevent getting same data we check that url has changed
-        // This prevents getting Category data, when sort or filter options have changed
+        // getIsNewCategory prevents getting Category data, when sort or filter options have changed
         if ((this._urlHasChanged(location, prevProps) && this.getIsNewCategory()) || categoryIds !== prevCategoryIds) {
             this._requestCategoryWithPageList();
         }


### PR DESCRIPTION
Restored `if` check on [Line](https://github.com/scandipwa/base-theme/compare/2.x-dev...mihailspopovs4:bug/category-multiple-requests?expand=1#diff-d9a0d79ad2ab3e3b086255ffbee9e932R125) as it was before https://github.com/scandipwa/base-theme/pull/286.
Added check for `isNewCategory`. It prevents getting Category info, when filter or sort options are changed.