### PR TITLE
Added option to sort products by Position

### DIFF
--- a/src/app/component/CategorySort/CategorySort.container.js
+++ b/src/app/component/CategorySort/CategorySort.container.js
@@ -36,6 +36,11 @@ export class CategorySortContainer extends PureComponent {
                 asc: __('%s: A to Z', label),
                 desc: __('%s: Z to A', label)
             };
+        case 'position':
+            return {
+                asc: __('%s: Ascending', label),
+                desc: __('%s: Descending', label)
+            };
         default:
             return {};
         }


### PR DESCRIPTION
Products can be sorted by position in Category page.
Are label texts ok?

Depends on https://github.com/scandipwa/catalog-graphql/pull/17