### PR TITLE
Checkout methods support: UPS

### DIFF
--- a/src/app/component/CheckoutAddressBook/CheckoutAddressBook.container.js
+++ b/src/app/component/CheckoutAddressBook/CheckoutAddressBook.container.js
@@ -27,7 +27,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
     static defaultProps = {
         isBilling: false,
         onAddressSelect: () => {},
-        onShippingEstimationFieldsChange:  () => {}
+        onShippingEstimationFieldsChange: () => {}
     };
 
     static _getDefaultAddressId(props) {
@@ -112,6 +112,7 @@ export class CheckoutAddressBookContainer extends PureComponent {
         const {
             city,
             country_id,
+            postcode,
             region: {
                 region_id,
                 region
@@ -124,7 +125,8 @@ export class CheckoutAddressBookContainer extends PureComponent {
             city,
             country_id,
             region_id,
-            region
+            region,
+            postcode
         });
     }
 

--- a/src/app/component/CheckoutAddressForm/CheckoutAddressForm.component.js
+++ b/src/app/component/CheckoutAddressForm/CheckoutAddressForm.component.js
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
 import FormPortal from 'Component/FormPortal';
+import { debounce } from 'Util/Request';
 import MyAccountAddressForm from 'Component/MyAccountAddressForm/MyAccountAddressForm.component';
 import './CheckoutAddressForm.style';
+
+export const UPDATE_STATE_FREQUENCY = 1000; // (ms)
 
 class CheckoutAddressForm extends MyAccountAddressForm {
     static propTypes = {
@@ -15,41 +18,43 @@ class CheckoutAddressForm extends MyAccountAddressForm {
         onShippingEstimationFieldsChange: () => {}
     };
 
+    onChange = debounce((key, value) => {
+        this.setState(() => ({ [key]: value }));
+    }, UPDATE_STATE_FREQUENCY);
+
     constructor(props) {
         super(props);
 
         const {
-            address: { region: { region = '' } = {} },
-            onShippingEstimationFieldsChange
+            address: { region: { region = '' } = {} }
         } = this.props;
 
         // TODO: get from region data
         this.state = {
             ...this.state,
             region,
-            city: ''
+            city: '',
+            postcode: ''
         };
 
         this.estimateShipping();
     }
-
-    onChange = (key, value) => {
-        this.setState(() => ({ [key]: value }));
-    };
 
     componentDidUpdate(_, prevState) {
         const {
             countryId,
             regionId,
             region,
-            city
+            city,
+            postcode
         } = this.state;
 
         const {
             countryId: prevCountryId,
             regionId: prevRegionId,
             region: prevRegion,
-            city: prevCity
+            city: prevCity,
+            postcode: prevpostcode
         } = prevState;
 
         if (
@@ -57,6 +62,7 @@ class CheckoutAddressForm extends MyAccountAddressForm {
             || regionId !== prevRegionId
             || city !== prevCity
             || region !== prevRegion
+            || postcode !== prevpostcode
         ) {
             this.estimateShipping();
         }
@@ -69,14 +75,16 @@ class CheckoutAddressForm extends MyAccountAddressForm {
             countryId,
             regionId,
             region,
-            city
+            city,
+            postcode
         } = this.state;
 
         onShippingEstimationFieldsChange({
             country_id: countryId,
             region_id: regionId,
             region,
-            city
+            city,
+            postcode
         });
     }
 
@@ -87,12 +95,18 @@ class CheckoutAddressForm extends MyAccountAddressForm {
             default_billing,
             default_shipping,
             city,
+            postcode,
             ...fieldMap
         } = super.fieldMap;
 
         fieldMap.city = {
             ...city,
             onChange: value => this.onChange('city', value)
+        };
+
+        fieldMap.postcode = {
+            ...postcode,
+            onChange: value => this.onChange('postcode', value)
         };
 
         return fieldMap;

--- a/src/app/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
+++ b/src/app/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.component.js
@@ -6,15 +6,11 @@ import CheckoutDeliveryOption from 'Component/CheckoutDeliveryOption';
 
 import './CheckoutDeliveryOptions.style';
 
-export const FLAT_RATE = 'flatrate';
-
 class CheckoutDeliveryOptions extends PureComponent {
     static propTypes = {
         shippingMethods: shippingMethodsType.isRequired,
         selectShippingMethod: PropTypes.func.isRequired,
-        selectedShippingMethodCode: PropTypes.oneOf([
-            FLAT_RATE
-        ])
+        selectedShippingMethodCode: PropTypes.string
     };
 
     static defaultProps = {
@@ -37,12 +33,12 @@ class CheckoutDeliveryOptions extends PureComponent {
             selectShippingMethod
         } = this.props;
 
-        const { carrier_code } = option;
-        const isSelected = selectedShippingMethodCode === carrier_code;
+        const { method_code } = option;
+        const isSelected = selectedShippingMethodCode === method_code;
 
         return (
             <CheckoutDeliveryOption
-              key={ carrier_code }
+              key={ method_code }
               isSelected={ isSelected }
               option={ option }
               onClick={ selectShippingMethod }

--- a/src/app/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.container.js
+++ b/src/app/component/CheckoutDeliveryOptions/CheckoutDeliveryOptions.container.js
@@ -62,7 +62,7 @@ export class CheckoutDeliveryOptionsContainer extends PureComponent {
 
         if (selectedShippingMethodCode !== prevSelectedShippingMethodCode) {
             const shippingMethod = shippingMethods.find(
-                ({ carrier_code }) => carrier_code === selectedShippingMethodCode
+                ({ method_code }) => method_code === selectedShippingMethodCode
             );
 
             onShippingMethodSelect(shippingMethod);
@@ -100,8 +100,8 @@ export class CheckoutDeliveryOptionsContainer extends PureComponent {
 
     selectShippingMethod(shippingMethod) {
         const { onShippingMethodSelect } = this.props;
-        const { carrier_code } = shippingMethod;
-        this.setState({ selectedShippingMethodCode: carrier_code });
+        const { method_code } = shippingMethod;
+        this.setState({ selectedShippingMethodCode: method_code });
         onShippingMethodSelect(shippingMethod);
     }
 

--- a/src/app/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/src/app/component/CheckoutShipping/CheckoutShipping.container.js
@@ -89,7 +89,7 @@ export class CheckoutShippingContainer extends PureComponent {
 
     _getAddressById(addressId) {
         const { customer: { addresses } } = this.props;
-        const address = addresses.find(({ id }) => id !== addressId);
+        const address = addresses.find(({ id }) => id === addressId);
         return trimCustomerAddress(address);
     }
 

--- a/src/app/route/Checkout/Checkout.container.js
+++ b/src/app/route/Checkout/Checkout.container.js
@@ -57,6 +57,7 @@ export class CheckoutContainer extends PureComponent {
         this.state = {
             isLoading: false,
             isDeliveryOptionsLoading: false,
+            requestsSent: 0,
             paymentMethods: [],
             shippingMethods: [],
             shippingAddress: {},
@@ -72,14 +73,25 @@ export class CheckoutContainer extends PureComponent {
     }
 
     onShippingEstimationFieldsChange(address) {
-        this.setState({ isDeliveryOptionsLoading: true });
+        const { requestsSent } = this.state;
+
+        this.setState({
+            isDeliveryOptionsLoading: true,
+            requestsSent: requestsSent + 1
+        });
 
         fetchMutation(CheckoutQuery.getEstimateShippingCosts(
             address,
             this._getGuestCartId()
         )).then(
             ({ estimateShippingCosts: shippingMethods }) => {
-                this.setState({ shippingMethods, isDeliveryOptionsLoading: false });
+                const { requestsSent } = this.state;
+
+                this.setState({
+                    shippingMethods,
+                    isDeliveryOptionsLoading: requestsSent > 1,
+                    requestsSent: requestsSent - 1
+                });
             },
             this._handleError
         );

--- a/src/app/util/Address/index.js
+++ b/src/app/util/Address/index.js
@@ -10,7 +10,7 @@ export const trimCustomerAddress = (customerAddress) => {
         postcode,
         street,
         telephone,
-        region,
+        region
     } = customerAddress;
 
     return {

--- a/src/app/util/Request/Request.js
+++ b/src/app/util/Request/Request.js
@@ -180,3 +180,13 @@ export const listenForBroadCast = name => new Promise((resolve) => {
         };
     }
 });
+
+export const debounce = (callback, delay) => {
+    // eslint-disable-next-line fp/no-let
+    let timeout;
+    return (...args) => {
+        const context = this;
+        clearTimeout(timeout);
+        timeout = setTimeout(() => callback.apply(context, args), delay);
+    };
+};


### PR DESCRIPTION
- Added support for UPS checkout method
- Fixed loader for checkout methods. Now `isLoading = false` only after all responses for checkout methods were received (before it was set immediately after the first response).
- Added Artjom's debounce feature

Requirements:
- M2 admin panel: `Stores > Configuration > Sales > Shipping methods > UPS` :
    * `Enabled for Checkout = Yes`
    * For testing purposes `UPS Type = United Parcel Service`, should be `United Parcel Service XML` in production.