### PR TITLE
Updated Production Webpack

### DIFF
--- a/src/config/webpack.production.config.js
+++ b/src/config/webpack.production.config.js
@@ -48,7 +48,7 @@ module.exports = {
         ],
         plugins: [
             new FallbackPlugin({
-                fallbackRoot, projectRoot
+                projectRoot, fallbackRoot
             })
         ]
     },


### PR DESCRIPTION
Updated Webpack to use the project index.production.html instead of the fallback index.production.html after a build