### PR TITLE
Layered navigation - attribute value types support

### DIFF
--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -144,7 +144,6 @@ export default class ProductAttributeValue extends Component {
                   elem="Image"
                   src={ `/media/attribute/swatch${img}` }
                   alt={ label }
-                  mods={ { isSelected } }
                 />
                 <data
                   block="ProductAttributeValue"

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -135,13 +135,27 @@ export default class ProductAttributeValue extends Component {
     }
 
     renderImageValue(img, label) {
+        const { isSelected } = this.props;
+
         return (
-            <img
-              block="ProductAttributeValue"
-              elem="Image"
-              src={ img }
-              alt={ label }
-            />
+            <>
+                <img
+                  block="ProductAttributeValue"
+                  elem="Image"
+                  src={ `/media/attribute/swatch${img}` }
+                  alt={ label }
+                  mods={ { isSelected } }
+                />
+                <data
+                  block="ProductAttributeValue"
+                  elem="Image-Overlay"
+                  value={ label }
+                  title={ label }
+                  style={ {
+                      '--option-is-selected': +isSelected
+                  } }
+                />
+            </>
         );
     }
 
@@ -153,7 +167,7 @@ export default class ProductAttributeValue extends Component {
               block="ProductAttributeValue"
               elem="String"
               mods={ { isSelected } }
-              title={ label }
+              title={ label || value }
             >
                 { value }
             </span>

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -43,14 +43,11 @@
         height: var(--option-size);
         width: var(--option-size);
         margin: var(--option-margin);
-    }
-
-    &-Color,
-    &-String {
         padding: var(--option-padding);
     }
 
     &-Image {
+        padding: 0;
         border-radius: 50%;
         position: relative;
     }

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -60,6 +60,11 @@
         position: absolute;
         top:0;
         left:0;
+        margin: .5rem;
+
+        @include after-mobile {
+            margin: 0;
+        }
     }
 
     &-Color,

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -55,8 +55,8 @@
     &-Image-Overlay {
         --option-check-mark-background: white;
         position: absolute;
-        top:0;
-        left:0;
+        top: 0;
+        left: 0;
         margin: .5rem;
 
         @include after-mobile {

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -41,11 +41,29 @@
         color: var(--option-text-color);
         display: inline-block;
         height: var(--option-size);
-        padding: var(--option-padding);
+        width: var(--option-size);
         margin: var(--option-margin);
     }
 
-    &-Color {
+    &-Color,
+    &-String {
+        padding: var(--option-padding);
+    }
+
+    &-Image {
+        border-radius: 50%;
+        position: relative;
+    }
+
+    &-Image-Overlay {
+        --option-check-mark-background: white;
+        position: absolute;
+        top:0;
+        left:0;
+    }
+
+    &-Color,
+    &-Image-Overlay {
         border-radius: 50%;
         font-size: 0;
         width: var(--option-size);
@@ -101,6 +119,7 @@
         border-style: solid;
         line-height: var(--option-size);
         min-width: calc(1.25 * var(--option-size));
+        width: auto;
         text-align: center;
 
         &_isSelected {


### PR DESCRIPTION
- Fixed width for text-swatch
- Fixed non-displaying alt for text/image-swatch
- Added overlay for image-swatch
- Fixed mobile alignment of Image-swatch overlay
- Added consistency in styling for color/image-swatch

Example of text-swatches with different width + image/color-swatches together:
![Selection_059](https://user-images.githubusercontent.com/53301511/67149156-2cb50880-f2a8-11e9-8841-f2d41917dd05.png)

Example of image-swatches `:hover` and `isSelected`:
![Selection_060](https://user-images.githubusercontent.com/53301511/67149166-4f472180-f2a8-11e9-8ad0-665481c8807f.png)