### PR TITLE
Layered navigation - Vertical dropdown support

### DIFF
--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -163,11 +163,11 @@ export default class ProductAttributeValue extends Component {
         const { isSelected } = this.props;
         return (
             <Field
-              id="value"
-              name="value"
+              id={ value }
+              name={ value }
               type="checkbox"
               label={ value }
-              value="value"
+              value={ value }
               mix={ { block: 'ProductAttributeValue', elem: 'Text', mods: { isSelected } } }
               checked={ isSelected }
             />
@@ -184,7 +184,7 @@ export default class ProductAttributeValue extends Component {
               block="ProductAttributeValue"
               elem={ isNotSwatch ? 'Text' : 'String' }
               mods={ { isSelected } }
-              title={ label || value }
+              title={ label }
             >
                 { value }
             </span>

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -144,7 +144,6 @@ export default class ProductAttributeValue extends Component {
                   elem="Image"
                   src={ `/media/attribute/swatch${img}` }
                   alt={ label }
-                  mods={ { isSelected } }
                 />
                 <data
                   block="ProductAttributeValue"

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -135,13 +135,27 @@ export default class ProductAttributeValue extends Component {
     }
 
     renderImageValue(img, label) {
+        const { isSelected } = this.props;
+
         return (
-            <img
-              block="ProductAttributeValue"
-              elem="Image"
-              src={ img }
-              alt={ label }
-            />
+            <>
+                <img
+                  block="ProductAttributeValue"
+                  elem="Image"
+                  src={ `/media/attribute/swatch${img}` }
+                  alt={ label }
+                  mods={ { isSelected } }
+                />
+                <data
+                  block="ProductAttributeValue"
+                  elem="Image-Overlay"
+                  value={ label }
+                  title={ label }
+                  style={ {
+                      '--option-is-selected': +isSelected
+                  } }
+                />
+            </>
         );
     }
 
@@ -153,7 +167,7 @@ export default class ProductAttributeValue extends Component {
               block="ProductAttributeValue"
               elem="String"
               mods={ { isSelected } }
-              title={ label }
+              title={ label || value }
             >
                 { value }
             </span>

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -160,11 +160,12 @@ export default class ProductAttributeValue extends Component {
 
     renderStringValue(value, label) {
         const { isSelected } = this.props;
+        const isNotSwatch = !label;
 
         return (
             <span
               block="ProductAttributeValue"
-              elem="String"
+              elem={ isNotSwatch ? 'Text' : 'String' }
               mods={ { isSelected } }
               title={ label || value }
             >

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -15,6 +15,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { AttributeType } from 'Type/ProductList';
 import { MixType } from 'Type/Common';
+import Field from 'Component/Field/Field.component';
 import './ProductAttributeValue.style';
 
 export default class ProductAttributeValue extends Component {
@@ -158,10 +159,26 @@ export default class ProductAttributeValue extends Component {
         );
     }
 
-    renderStringValue(value, label) {
+    renderDropdown(value) {
         const { isSelected } = this.props;
-        const isNotSwatch = !label;
+        return (
+            <Field
+              id="value"
+              name="value"
+              type="checkbox"
+              label={ value }
+              value="value"
+              mix={ { block: 'ProductAttributeValue', elem: 'Text', mods: { isSelected } } }
+              checked={ isSelected }
+            />
+        );
+    }
 
+    renderStringValue(value, label) {
+        const isNotSwatch = !label;
+        if (isNotSwatch) return this.renderDropdown(value);
+
+        const { isSelected } = this.props;
         return (
             <span
               block="ProductAttributeValue"

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -132,6 +132,56 @@
         }
     }
 
+    &-Text {
+        display: flex;
+        border: 0;
+        align-items: center;
+        margin: 0;
+        text-transform: uppercase;
+
+        &_isSelected {
+            color: var(--color-primary-base);
+        }
+
+        label {
+            font-weight: 400;
+            margin: 0;
+            cursor: pointer;
+
+            &:first-of-type {
+                order: 1;
+                padding-left: 1rem;
+                padding-bottom: 0;
+
+                ~ label {
+                    margin: 0;
+                }
+            }
+        }
+
+        &:hover {
+            label {
+                @include after-mobile {
+                    border-color: $primary-base-color;
+                }
+
+                &::after {
+                    @include after-mobile {
+                        --checkmark-color: #{$dusty-grey};
+                    }
+                }
+            }
+        }
+
+        @include after-mobile {
+            padding: 0;
+        }
+    }
+
+    &:hover {
+        text-decoration: none;
+    }
+
     &_isNotAvailable {
         opacity: .25;
         pointer-events: none;

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -43,14 +43,11 @@
         height: var(--option-size);
         width: var(--option-size);
         margin: var(--option-margin);
-    }
-
-    &-Color,
-    &-String {
         padding: var(--option-padding);
     }
 
     &-Image {
+        padding: 0;
         border-radius: 50%;
         position: relative;
     }

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -60,6 +60,11 @@
         position: absolute;
         top:0;
         left:0;
+        margin: .5rem;
+
+        @include after-mobile {
+            margin: 0;
+        }
     }
 
     &-Color,

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -55,8 +55,8 @@
     &-Image-Overlay {
         --option-check-mark-background: white;
         position: absolute;
-        top:0;
-        left:0;
+        top: 0;
+        left: 0;
         margin: .5rem;
 
         @include after-mobile {

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -41,11 +41,29 @@
         color: var(--option-text-color);
         display: inline-block;
         height: var(--option-size);
-        padding: var(--option-padding);
+        width: var(--option-size);
         margin: var(--option-margin);
     }
 
-    &-Color {
+    &-Color,
+    &-String {
+        padding: var(--option-padding);
+    }
+
+    &-Image {
+        border-radius: 50%;
+        position: relative;
+    }
+
+    &-Image-Overlay {
+        --option-check-mark-background: white;
+        position: absolute;
+        top:0;
+        left:0;
+    }
+
+    &-Color,
+    &-Image-Overlay {
         border-radius: 50%;
         font-size: 0;
         width: var(--option-size);
@@ -101,6 +119,7 @@
         border-style: solid;
         line-height: var(--option-size);
         min-width: calc(1.25 * var(--option-size));
+        width: auto;
         text-align: center;
 
         &_isSelected {

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.style.scss
@@ -34,7 +34,8 @@
 
     &-Color,
     &-String,
-    &-Image {
+    &-Image,
+    &-Text {
         background-color: var(--option-background-color);
         border-color: var(--option-border-color);
         border-width: 1px;
@@ -117,7 +118,8 @@
         }
     }
 
-    &-String {
+    &-String,
+    &-Text {
         border-style: solid;
         line-height: var(--option-size);
         min-width: calc(1.25 * var(--option-size));

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.component.js
@@ -135,7 +135,12 @@ export default class ProductConfigurableAttributes extends Component {
         const { configurable_options, isContentExpanded } = this.props;
 
         return Object.values(configurable_options).map((option) => {
-            const { attribute_values, attribute_label, attribute_code } = option;
+            const {
+                attribute_values, attribute_label, attribute_code,
+                attribute_options
+            } = option;
+            const { swatch_data } = attribute_options[Object.keys(attribute_options)[0]];
+            const isNotSwatch = !swatch_data;
 
             return (
                 <ExpandableContent
@@ -145,7 +150,10 @@ export default class ProductConfigurableAttributes extends Component {
                   mix={ { block: 'ProductConfigurableAttributes', elem: 'Expandable' } }
                   isContentExpanded={ isContentExpanded }
                 >
-                    <div block="ProductConfigurableAttributes" elem="AttributesList">
+                    <div
+                      block="ProductConfigurableAttributes"
+                      elem={ isNotSwatch ? 'AttributesVerticalList' : 'AttributesList' }
+                    >
                         { attribute_values.map(attribute_value => (
                             this.renderConfigurableAttributeValue({ ...option, attribute_value })
                         )) }

--- a/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
+++ b/src/app/component/ProductConfigurableAttributes/ProductConfigurableAttributes.style.scss
@@ -20,7 +20,8 @@
 }
 
 .ProductConfigurableAttributes {
-    &-AttributesList {
+    &-AttributesList,
+    &-AttributesVerticalList {
         text-align: center;
         display: flex;
         flex-wrap: wrap;
@@ -33,6 +34,11 @@
             display: flex;
             flex-wrap: wrap;
         }
+    }
+
+    &-AttributesVerticalList {
+        flex-direction: column;
+        align-items: start;
     }
 
     &-Expandable {


### PR DESCRIPTION
- Added support for dropdowns in Layered navigation
- Swatch-type attributes show horizontally now, while others - vertically
- Added checkboxes for dropdown list items and fixed :hover for them

This is the example of a dropdown:
![Selection_055](https://user-images.githubusercontent.com/53301511/67193653-ef5e9100-f3f5-11e9-9aee-4fddf6fcfd34.png)
