### PR TITLE
Fixed grand total in checkout

### DIFF
--- a/src/app/route/Checkout/Checkout.container.js
+++ b/src/app/route/Checkout/Checkout.container.js
@@ -143,11 +143,10 @@ export class CheckoutContainer extends PureComponent {
 
     _getCheckoutTotals() {
         const { totals: cartTotals } = this.props;
-        const { items } = cartTotals;
-        const { paymentTotals } = this.state;
+        const { paymentTotals: { shipping_amount } } = this.state;
 
-        return Object.keys(paymentTotals).length
-            ? { ...cartTotals, ...paymentTotals, items }
+        return shipping_amount
+            ? { ...cartTotals, shipping_amount }
             : cartTotals;
     }
 


### PR DESCRIPTION
Using only shipping data returned from shipping address, checkout data is showing precisely. In order to fix it on BE and use then returned data from saveAddress resolver, resolver should be rewritten using totals collection logic I believe. (At least I have seen it in M2 implementation).