### PR TITLE
Fix the image path on the cms pages for the sliders

### DIFF
--- a/src/app/component/SliderWidget/SliderWidget.component.js
+++ b/src/app/component/SliderWidget/SliderWidget.component.js
@@ -65,7 +65,7 @@ export default class SliderWidget extends PureComponent {
                 <Image
                   mix={ { block: 'SliderWidget', elem: 'FigureImage' } }
                   ratio="custom"
-                  src={ image }
+                  src={ '/' + image }
                   isPlaceholder={ isPlaceholder }
                 />
                 <figcaption


### PR DESCRIPTION
On the cms page with the url "/page/about-us" the slider was searching for the /page/media/slider/... images, but on the /about-us url it worked. Now it works for both in both of our environments.