### PR TITLE
Top/bottom position of price range in layered navigation

### DIFF
--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -27,6 +27,8 @@ export default class CategoryFilterOverlay extends PureComponent {
         }).isRequired,
         minPriceValue: PropTypes.number.isRequired,
         maxPriceValue: PropTypes.number.isRequired,
+        priceOnTop: PropTypes.bool.isRequired,
+        isLoading: PropTypes.bool.isRequired,
         onSeeResultsClick: PropTypes.func.isRequired,
         customFiltersValues: PropTypes.objectOf(PropTypes.array).isRequired,
         toggleCustomFilter: PropTypes.func.isRequired,
@@ -38,8 +40,11 @@ export default class CategoryFilterOverlay extends PureComponent {
             updatePriceRange,
             priceValue,
             minPriceValue,
-            maxPriceValue
+            maxPriceValue,
+            isLoading
         } = this.props;
+
+        if (isLoading) return null;
 
         const { min, max } = priceValue;
 
@@ -108,12 +113,31 @@ export default class CategoryFilterOverlay extends PureComponent {
         );
     }
 
+    renderFiltersAndPrice() {
+        const { priceOnTop } = this.props;
+
+        if (priceOnTop) {
+            return (
+                <>
+                    { this.renderPriceRange() }
+                    { this.renderFilters() }
+                </>
+            );
+        }
+
+        return (
+            <>
+                { this.renderFilters() }
+                { this.renderPriceRange() }
+            </>
+        );
+    }
+
     render() {
         return (
             <Overlay mix={ { block: 'CategoryFilterOverlay' } } id="category-filter">
                 { this.renderHeading() }
-                { this.renderFilters() }
-                { this.renderPriceRange() }
+                { this.renderFiltersAndPrice() }
                 { this.renderSeeResults() }
             </Overlay>
         );

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.style.scss
@@ -90,8 +90,6 @@
     }
 
     &-Filter {
-        order: 50;
-
         @include after-mobile {
             margin-bottom: 1rem;
         }

--- a/src/app/query/ProductList.query.js
+++ b/src/app/query/ProductList.query.js
@@ -105,6 +105,7 @@ export class ProductListQuery {
             return [
                 'min_price',
                 'max_price',
+                'price_on_top',
                 this._getSortField(),
                 this._getFiltersField()
             ];

--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -27,6 +27,8 @@ export default class CategoryPage extends PureComponent {
         category: CategoryTreeType.isRequired,
         minPriceRange: PropTypes.number.isRequired,
         maxPriceRange: PropTypes.number.isRequired,
+        priceOnTop: PropTypes.bool.isRequired,
+        isInfoLoading: PropTypes.bool.isRequired,
         getIsNewCategory: PropTypes.func.isRequired,
         filters: PropTypes.objectOf(PropTypes.shape).isRequired,
         sortFields: PropTypes.shape({
@@ -94,7 +96,9 @@ export default class CategoryPage extends PureComponent {
             selectedPriceRange,
             updatePriceRange,
             updateFilter,
-            getFilterUrl
+            getFilterUrl,
+            priceOnTop,
+            isInfoLoading
         } = this.props;
 
         return (
@@ -107,6 +111,8 @@ export default class CategoryPage extends PureComponent {
               priceValue={ selectedPriceRange }
               minPriceValue={ minPriceRange }
               maxPriceValue={ maxPriceRange }
+              priceOnTop={ priceOnTop }
+              isLoading={ isInfoLoading }
             />
         );
     }

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -42,6 +42,7 @@ export const mapStateToProps = state => ({
     sortFields: state.ProductListInfoReducer.sortFields,
     minPriceRange: state.ProductListInfoReducer.minPrice,
     maxPriceRange: state.ProductListInfoReducer.maxPrice,
+    priceOnTop: state.ProductListInfoReducer.price_on_top,
     isInfoLoading: state.ProductListInfoReducer.isLoading
 });
 

--- a/src/app/store/ProductListInfo/ProductListInfo.reducer.js
+++ b/src/app/store/ProductListInfo/ProductListInfo.reducer.js
@@ -53,6 +53,7 @@ const reduceFilters = filters => filters.reduce((co, item) => {
 export const initialState = {
     minPrice: 0,
     maxPrice: 0,
+    price_on_top: false,
     sortFields: {},
     filters: {},
     isLoading: true
@@ -66,6 +67,7 @@ const ProductListReducer = (state = initialState, action) => {
             filters: availableFilters = [],
             min_price,
             max_price,
+            price_on_top,
             sort_fields: sortFields
         } = {}
     } = action;
@@ -78,6 +80,7 @@ const ProductListReducer = (state = initialState, action) => {
             sortFields,
             minPrice: Math.floor(min_price),
             maxPrice: Math.ceil(max_price),
+            price_on_top,
             isLoading: false
         };
 


### PR DESCRIPTION
* Added support for top/bottom position of price range in layered navigation

Depends on https://github.com/scandipwa/catalog-graphql/pull/29

How to use:
* Go to `M2 > Stores > Product` and choose attribute with `Attribute Code = Price`
* Choose `Storefront Properties` category.
* Use `Position` field for controlling the position : If catalog input type is Price, use `0` for positioning price slider at the bottom and other for positioning at the top.

Examples:
* Settings:
![Selection_013](https://user-images.githubusercontent.com/53301511/68549295-e9594000-03f6-11ea-9c28-68709cbe0c2f.png)
* With `Position = 0`:
  * ![Selection_014](https://user-images.githubusercontent.com/53301511/68549326-21f91980-03f7-11ea-865a-7a56962daf0e.png)
  * ![Selection_015](https://user-images.githubusercontent.com/53301511/68549331-2ae9eb00-03f7-11ea-8c8e-0899f8cd2818.png)
* With `Position > 0`:
  * ![Selection_017](https://user-images.githubusercontent.com/53301511/68549338-3806da00-03f7-11ea-9459-2e49a3fbfc75.png)
  * ![Selection_016](https://user-images.githubusercontent.com/53301511/68549343-3f2de800-03f7-11ea-8b70-9b46cf44df19.png)


