### PR TITLE
Fetch and use category default sort order

### DIFF
--- a/src/app/query/Category.query.js
+++ b/src/app/query/Category.query.js
@@ -67,6 +67,7 @@ export class CategoryQuery {
             'product_count',
             'meta_keywords',
             'meta_description',
+            'default_sort_by',
             this._getBreadcrumbsField()
         ];
     }

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -244,9 +244,10 @@ export class CategoryPageContainer extends PureComponent {
     }
 
     _getSelectedSortFromUrl() {
-        const { location } = this.props;
-        const { sortKey: defaultSortKey, sortDirection: defaultSortDirection } = this.config;
+        const { location, category: { default_sort_by } } = this.props;
+        const { sortKey: globalDefaultSortKey, sortDirection: defaultSortDirection } = this.config;
         const sortDirection = getQueryParam('sortDirection', location) || defaultSortDirection;
+        const defaultSortKey = default_sort_by || globalDefaultSortKey;
         const sortKey = getQueryParam('sortKey', location) || defaultSortKey;
         return { sortDirection, sortKey };
     }


### PR DESCRIPTION
Hi @alfredsgenkins,

This is the implementation for SWPWA-196. If a valid default sort order has been defined for the current category, it will be used.

Please take a look. Thanks!