### PR TITLE
Copyright notice logo (with logo component)

### DIFF
--- a/src/app/component/Footer/Footer.component.js
+++ b/src/app/component/Footer/Footer.component.js
@@ -12,6 +12,9 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'Component/Link';
+import Logo from 'Component/Logo';
+import media from 'Util/Media';
+import { LOGO_MEDIA } from 'Util/Media/Media';
 import './Footer.style';
 
 /**
@@ -20,19 +23,64 @@ import './Footer.style';
  */
 export default class Footer extends PureComponent {
     static propTypes = {
-        copyright: PropTypes.string
+        copyright: PropTypes.string,
+        header_logo_src: PropTypes.string,
+        logo_alt: PropTypes.string,
+        isLoading: PropTypes.bool
     };
 
     static defaultProps = {
+        logo_alt: 'ScandiPWA logo',
+        header_logo_src: '',
+        isLoading: true,
         copyright: ''
     };
+
+    renderLogoImage() {
+        const {
+            header_logo_src,
+            logo_alt
+        } = this.props;
+
+        return (
+            <Logo
+              src={ media(header_logo_src, LOGO_MEDIA) }
+              alt={ logo_alt }
+              footerLogo
+            />
+        );
+    }
+
+    renderLogo(isVisible = false) {
+        const { isLoading } = this.props;
+
+        if (isLoading) return null;
+        return (
+            <Link
+              to="/"
+              aria-label="Go to homepage by clicking on ScandiPWA logo"
+              aria-hidden={ !isVisible }
+              tabIndex={ isVisible ? 0 : -1 }
+              block="Footer"
+              elem="LogoWrapper"
+              mods={ { isVisible } }
+              key="logo"
+              itemScope
+              itemType="http://schema.org/Organization"
+            >
+                <meta itemProp="legalName" content="ScandiPWA" />
+                <meta itemProp="parentOrganization" content="Scandiweb" />
+                { this.renderLogoImage() }
+            </Link>
+        );
+    }
 
     render() {
         const { copyright } = this.props;
 
         return (
             <footer block="Footer" aria-label="Footer">
-                <div>
+                <div block="Footer" elem="Wrapper">
                     <Link
                       block="Footer"
                       elem="Link"
@@ -48,6 +96,7 @@ export default class Footer extends PureComponent {
                         { __('Shopping terms and conditions') }
                     </Link>
                     <span block="Footer" elem="Copyright">{ copyright }</span>
+                    { this.renderLogo() }
                 </div>
             </footer>
         );

--- a/src/app/component/Footer/Footer.container.js
+++ b/src/app/component/Footer/Footer.container.js
@@ -12,6 +12,9 @@ import { connect } from 'react-redux';
 import Footer from './Footer.component';
 
 export const mapStateToProps = state => ({
+    header_logo_src: state.ConfigReducer.header_logo_src,
+    logo_alt: state.ConfigReducer.logo_alt,
+    isLoading: state.ConfigReducer.isLoading,
     copyright: state.ConfigReducer.copyright
 });
 

--- a/src/app/component/Footer/Footer.style.scss
+++ b/src/app/component/Footer/Footer.style.scss
@@ -11,6 +11,8 @@
 
 :root {
     --footer-height: 150px;
+    --footer-logo-width: 200px;
+    --footer-logo-height: calc(var(--footer-height) - 135px);
 }
 
 .Footer {
@@ -36,5 +38,21 @@
 
     &-Copyright {
         display: block;
+    }
+
+    &-Wrapper {
+        top: -10px;
+    }
+
+    &-LogoWrapper {
+        position: absolute;
+        height: var(--footer-logo-height);
+        width: var(--footer-logo-width);
+        max-width: 100%;
+        left: 0;
+        right: 0;
+        margin: auto;
+        margin-top: 5px;
+        overflow: hidden;
     }
 }

--- a/src/app/component/Logo/Logo.component.js
+++ b/src/app/component/Logo/Logo.component.js
@@ -15,16 +15,33 @@ import Image, {
     IMAGE_NOT_FOUND,
     IMAGE_NOT_SPECIFIED
 } from 'Component/Image/Image.component';
+import PropTypes from 'prop-types';
 
 import './Logo.style';
 
 class Logo extends Image {
+    static propTypes = {
+        ...Image.propTypes,
+        footerLogo: PropTypes.bool
+    };
+
+    static defaultProps = {
+        ...Image.defaultProps,
+        footerLogo: false
+    };
+
     renderPlaceholderLogo() {
+        const { footerLogo } = this.props;
+        const size = footerLogo
+            ? {
+                width: 116, height: 10, viewBox: '0 0 116 17'
+            }
+            : { width: 116, height: 17 };
+
         return (
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="116"
-              height="17"
+              { ...size }
               block="Logo"
               elem="Placeholder"
             >

--- a/src/app/component/Slider/Slider.component.js
+++ b/src/app/component/Slider/Slider.component.js
@@ -84,8 +84,6 @@ export default class Slider extends PureComponent {
         const sliderWidth = this.draggableRef.current.offsetWidth;
         this.sliderWidth = sliderWidth;
 
-        if (!sliderChildren[0]) return;
-
         sliderChildren[0].onload = () => {
             CSS.setVariable(this.sliderRef, 'slider-height', `${sliderChildren[0].offsetHeight}px`);
         };

--- a/src/app/component/Slider/Slider.component.js
+++ b/src/app/component/Slider/Slider.component.js
@@ -84,6 +84,8 @@ export default class Slider extends PureComponent {
         const sliderWidth = this.draggableRef.current.offsetWidth;
         this.sliderWidth = sliderWidth;
 
+        if (!sliderChildren[0]) return;
+
         sliderChildren[0].onload = () => {
             CSS.setVariable(this.sliderRef, 'slider-height', `${sliderChildren[0].offsetHeight}px`);
         };


### PR DESCRIPTION
- Added support for Store Logo in copyright block inside `Footer` component

Example:
- No logo
  - Mobile
![Selection_019](https://user-images.githubusercontent.com/53301511/69002614-19bb4580-08f3-11ea-952e-3b3a60c1d3e7.png)
  - Desktop
![Selection_018](https://user-images.githubusercontent.com/53301511/69002618-1cb63600-08f3-11ea-9ebd-c88612c12c6d.png)
- Custom logo
  - Mobile
![Selection_017](https://user-images.githubusercontent.com/53301511/69002622-23dd4400-08f3-11ea-9282-668820ffe07e.png)
  - Desktop
![Selection_016](https://user-images.githubusercontent.com/53301511/69002623-29d32500-08f3-11ea-9bba-c835c2ee2b83.png)
