### PR TITLE
Fix bug where resetting a password would not work

### DIFF
--- a/src/app/component/MyAccountOverlay/MyAccountOverlay.component.js
+++ b/src/app/component/MyAccountOverlay/MyAccountOverlay.component.js
@@ -46,7 +46,6 @@ class MyAccountOverlay extends PureComponent {
         onForgotPasswordAttempt: PropTypes.func.isRequired,
         onFormError: PropTypes.func.isRequired,
         handleForgotPassword: PropTypes.func.isRequired,
-        handleForgotPasswordSuccess: PropTypes.func.isRequired,
         handleSignIn: PropTypes.func.isRequired,
         handleCreateAccount: PropTypes.func.isRequired
     };
@@ -90,7 +89,6 @@ class MyAccountOverlay extends PureComponent {
             onForgotPasswordAttempt,
             onForgotPasswordSuccess,
             onFormError,
-            handleForgotPasswordSuccess,
             handleSignIn,
             handleCreateAccount
         } = this.props;
@@ -105,7 +103,7 @@ class MyAccountOverlay extends PureComponent {
                 >
                     <Field type="text" id="email" name="email" label="Email" validation={ ['notEmpty', 'email'] } />
                     <div block="MyAccountOverlay" elem="Buttons">
-                        <button block="Button" type="submit" onClick={ handleForgotPasswordSuccess }>
+                        <button block="Button" type="submit">
                             { __('Send reset link') }
                         </button>
                     </div>

--- a/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -66,7 +66,6 @@ export class MyAccountOverlayContainer extends PureComponent {
         onForgotPasswordAttempt: this.onForgotPasswordAttempt.bind(this),
         onFormError: this.onFormError.bind(this),
         handleForgotPassword: this.handleForgotPassword.bind(this),
-        handleForgotPasswordSuccess: this.handleForgotPasswordSuccess.bind(this),
         handleSignIn: this.handleSignIn.bind(this),
         handleCreateAccount: this.handleCreateAccount.bind(this)
     };
@@ -189,7 +188,10 @@ export class MyAccountOverlayContainer extends PureComponent {
 
     onForgotPasswordSuccess(fields) {
         const { forgotPassword } = this.props;
-        forgotPassword(fields).then(this.stopLoading, this.stopLoading);
+        forgotPassword(fields).then(() => {
+            this.setState({ state: STATE_FORGOT_PASSWORD_SUCCESS });
+            this.stopLoading();
+        }, this.stopLoading);
     }
 
     onForgotPasswordAttempt() {
@@ -208,10 +210,6 @@ export class MyAccountOverlayContainer extends PureComponent {
         e.nativeEvent.stopImmediatePropagation();
         this.setState({ state: STATE_FORGOT_PASSWORD });
         setHeaderState({ name: CUSTOMER_ACCOUNT, title: 'Forgot password' });
-    }
-
-    handleForgotPasswordSuccess() {
-        this.setState({ state: STATE_FORGOT_PASSWORD_SUCCESS });
     }
 
     handleSignIn(e) {


### PR DESCRIPTION
Currently, clicking "send reset link" in the reset password overlay doesn't do anything. Fixed:

Now it displays a loading screen, then:
![attels](https://user-images.githubusercontent.com/11248241/69134547-8bd88980-0aaf-11ea-840d-ccaad97814f9.png)

or
![attels](https://user-images.githubusercontent.com/11248241/69134572-98f57880-0aaf-11ea-95c6-727cd905381e.png)

...as it did before.