### PR TITLE
Currency Switcher UI in Header

### DIFF
--- a/src/app/component/CurrencySwitcher/CurrencySwitcher.component.js
+++ b/src/app/component/CurrencySwitcher/CurrencySwitcher.component.js
@@ -1,0 +1,69 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+import React, { PureComponent } from 'react';
+import { setCurrency, getCurrency } from 'Util/Currency/Current';
+import PropTypes from 'prop-types';
+import Field from 'Component/Field/Field.container';
+
+class CurrencySwitcherComponent extends PureComponent {
+    static propTypes = {
+        setCurrencyData: PropTypes.func.isRequired,
+        currency: PropTypes.object.isRequired
+    };
+
+    changeCurrency(value) {
+        if (value !== getCurrency()) {
+            setCurrency(value);
+            window.location.reload();
+        }
+    }
+
+    renderCurrencyList() {
+        const { currency } = this.props;
+        const currencyCodes = currency.currency_codes ? currency.currency_codes : [];
+        const availableCurrency = currencyCodes.filter(elem => elem.rate > 0);
+        const selectOptions = [];
+        availableCurrency.map((currency) => {
+            selectOptions.push({
+                id: currency.currency_to,
+                label: currency.currency_to,
+                value: currency.currency_to
+            });
+
+            return 0;
+        });
+
+        if (availableCurrency.length > 1) {
+            return (
+                <Field
+                  id="currency-switcher"
+                  name="currency-switcher"
+                  type="select"
+                  selectOptions={ selectOptions }
+                  value={ getCurrency() }
+                  onChange={ this.changeCurrency }
+                />
+            );
+        }
+
+        return null;
+    }
+
+    render() {
+        return (
+            <div block="currency">
+                { this.renderCurrencyList() }
+            </div>
+        );
+    }
+}
+
+export default CurrencySwitcherComponent;

--- a/src/app/component/CurrencySwitcher/CurrencySwitcher.container.js
+++ b/src/app/component/CurrencySwitcher/CurrencySwitcher.container.js
@@ -1,0 +1,96 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+import React, { PureComponent } from 'react';
+import { executeGet } from 'Util/Request';
+import { ONE_MONTH_IN_SECONDS } from 'Util/Request/QueryDispatcher';
+import { prepareQuery } from 'Util/Query';
+import CurrencyQuery from 'Query/Currency.query';
+import { setCurrencyData } from 'Store/Currency';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { setCurrency, getCurrency } from 'Util/Currency/Current';
+import CurrencySwitcherComponent from './CurrencySwitcher.component';
+
+export const mapDispatchToProps = dispatch => ({
+    setCurrencyData: data => dispatch(setCurrencyData(data))
+});
+
+export const mapStateToProps = state => ({
+    currency: state.CurrencyReducer.currency,
+    default_display_currency_code: state.ConfigReducer.default_display_currency_code
+});
+
+export class CurrencySwitcherContainer extends PureComponent {
+    static propTypes = {
+        setCurrencyData: PropTypes.func.isRequired,
+        currency: PropTypes.object.isRequired,
+        default_display_currency_code: PropTypes.string.isRequired
+    };
+
+    componentDidMount() {
+        this._requestStoreCurrencies();
+    }
+
+    _requestStoreCurrencies() {
+        const { setCurrencyData } = this.props;
+        const query = [CurrencyQuery.getCurrencyMutation()];
+        executeGet(prepareQuery(query), 'Currency', ONE_MONTH_IN_SECONDS, false)
+            .then((data) => {
+                // Clears the Currency of localstorage if same data is not present in the API
+                if (!data.currency.currency_codes.find(code => code.rate > 0 && code.currency_to === getCurrency())) {
+                    setCurrency('');
+                    window.location.reload();
+                } else {
+                    setCurrencyData(data);
+                }
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    }
+
+    validatedCurrencyCodes() {
+        const { currency, default_display_currency_code } = this.props;
+
+        const currencyCodes = currency.currency_codes ? currency.currency_codes : [];
+        const availableCurrency = [];
+
+        currencyCodes.map((currencyCode) => {
+            if (currencyCode.rate > 0) {
+                availableCurrency.push(currencyCode.currency_to);
+            }
+
+            return 0;
+        });
+
+        if (availableCurrency.length > 1) {
+            const code = getCurrency();
+
+            if (availableCurrency.indexOf(code) >= 0) {
+                setCurrency(code);
+            } else {
+                setCurrency(default_display_currency_code);
+            }
+        }
+    }
+
+    render() {
+        this.validatedCurrencyCodes();
+        return (
+            <CurrencySwitcherComponent
+              { ...this.props }
+              { ...this.state }
+            />
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CurrencySwitcherContainer);

--- a/src/app/component/CurrencySwitcher/index.js
+++ b/src/app/component/CurrencySwitcher/index.js
@@ -1,0 +1,11 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+export { default } from './CurrencySwitcher.container';

--- a/src/app/component/Header/Header.component.js
+++ b/src/app/component/Header/Header.component.js
@@ -338,7 +338,6 @@ export default class Header extends PureComponent {
             logo_alt
         } = this.props;
 
-        if (!header_logo_src) return null;
 
         return (
             <Logo

--- a/src/app/component/Header/Header.component.js
+++ b/src/app/component/Header/Header.component.js
@@ -11,7 +11,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
-import { PureComponent, Fragment, createRef } from 'react';
+import React, { PureComponent, Fragment, createRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Link from 'Component/Link';
@@ -22,6 +22,7 @@ import CartOverlay from 'Component/CartOverlay';
 import ClickOutside from 'Component/ClickOutside';
 import SearchOverlay from 'Component/SearchOverlay';
 import MyAccountOverlay from 'Component/MyAccountOverlay';
+import CurrencySwitcher from 'Component/CurrencySwitcher';
 
 import './Header.style';
 import media from 'Util/Media';
@@ -106,13 +107,15 @@ export default class Header extends PureComponent {
         [PDP]: {
             back: true,
             title: true,
-            minicart: true
+            minicart: true,
+            currency_switcher: true
         },
         [CATEGORY]: {
             back: true,
             menu: true,
             title: true,
-            minicart: true
+            minicart: true,
+            currency_switcher: true
         },
         [CUSTOMER_ACCOUNT]: {
             close: true,
@@ -127,6 +130,7 @@ export default class Header extends PureComponent {
             title: true,
             account: true,
             minicart: true,
+            currency_switcher: true,
             logo: true
         },
         [MENU]: {
@@ -174,6 +178,7 @@ export default class Header extends PureComponent {
         search: this.renderSearchField.bind(this),
         title: this.renderTitle.bind(this),
         logo: this.renderLogo.bind(this),
+        currency_switcher: this.renderCurrencySwitcher.bind(this),
         account: this.renderAccountButton.bind(this),
         minicart: this.renderMinicartButton.bind(this),
         clear: this.renderClearButton.bind(this),
@@ -225,6 +230,25 @@ export default class Header extends PureComponent {
         );
     }
 
+    /**
+     *
+     * @returns {CurrencySwitcher}
+     */
+    renderCurrencySwitcher(isVisible = false) {
+        return (
+            <div
+              block="Header"
+              elem="CurrencySwitcher"
+              key="currency-switcher"
+              mods={ { isVisible, type: 'currency-switcher' } }
+              aria-label="Currency Switcher"
+            >
+                <CurrencySwitcher />
+            </div>
+
+        );
+    }
+
     renderMenuButton(isVisible = false) {
         const { onMenuOutsideClick, onMenuButtonClick } = this.props;
 
@@ -260,23 +284,23 @@ export default class Header extends PureComponent {
                       elem="SearchWrapper"
                       aria-label="Search"
                     >
-                            <input
-                              id="search-field"
-                              ref={ this.searchBarRef }
-                              placeholder="Type a new search"
-                              block="Header"
-                              elem="SearchField"
-                              onClick={ onSearchBarClick }
-                              onChange={ onSearchBarChange }
-                              value={ searchCriteria }
-                              mods={ {
-                                  isVisible: isSearchVisible,
-                                  type: 'searchField'
-                              } }
-                            />
-                            <SearchOverlay
-                              searchCriteria={ searchCriteria }
-                            />
+                        <input
+                          id="search-field"
+                          ref={ this.searchBarRef }
+                          placeholder="Type a new search"
+                          block="Header"
+                          elem="SearchField"
+                          onClick={ onSearchBarClick }
+                          onChange={ onSearchBarChange }
+                          value={ searchCriteria }
+                          mods={ {
+                              isVisible: isSearchVisible,
+                              type: 'searchField'
+                          } }
+                        />
+                        <SearchOverlay
+                          searchCriteria={ searchCriteria }
+                        />
                     </div>
                 </ClickOutside>
                 <button
@@ -313,6 +337,8 @@ export default class Header extends PureComponent {
             header_logo_src,
             logo_alt
         } = this.props;
+
+        if (!header_logo_src) return null;
 
         return (
             <Logo

--- a/src/app/component/Header/Header.style.scss
+++ b/src/app/component/Header/Header.style.scss
@@ -377,21 +377,26 @@
             }
         }
     }
-    &-CurrencySwitcher{
-        .currency{
+
+    &-CurrencySwitcher {
+        .currency {
             min-width: 80px;
             margin-right: 5px;
-            .Field{
+
+            .Field {
                 margin-top: 0;
             }
         }
-        select{
+
+        select {
             padding: 10px;
             margin-right: 5px;
         }
+
         @include mobile {
             width: 0;
             opacity: 0;
+
             &_isVisible {
                 opacity: 1;
                 width: auto;

--- a/src/app/component/Header/Header.style.scss
+++ b/src/app/component/Header/Header.style.scss
@@ -377,4 +377,25 @@
             }
         }
     }
+    &-CurrencySwitcher{
+        .currency{
+            min-width: 80px;
+            margin-right: 5px;
+            .Field{
+                margin-top: 0;
+            }
+        }
+        select{
+            padding: 10px;
+            margin-right: 5px;
+        }
+        @include mobile {
+            width: 0;
+            opacity: 0;
+            &_isVisible {
+                opacity: 1;
+                width: auto;
+            }
+        }
+    }
 }

--- a/src/app/query/Currency.query.js
+++ b/src/app/query/Currency.query.js
@@ -1,0 +1,38 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+import { Field } from 'Util/Query';
+
+export class CurrencyQuery {
+    getCurrencyMutation() {
+        return new Field('currency')
+            .addFieldList(this._currencyFieldLists());
+    }
+
+    _currencyFieldLists() {
+        return [
+            'available_currency_codes',
+            'base_currency_code',
+            'default_display_currency_code',
+            this._getExchangeRates()
+        ];
+    }
+
+    _getExchangeRates() {
+        return new Field('exchange_rates')
+            .setAlias('currency_codes')
+            .addFieldList([
+                'currency_to',
+                'rate'
+            ]);
+    }
+}
+
+export default new CurrencyQuery();

--- a/src/app/store/Currency/Currency.action.js
+++ b/src/app/store/Currency/Currency.action.js
@@ -1,0 +1,25 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+/**
+ *
+ * @type {string}
+ */
+export const SET_CURRENCY_DATA = 'SET_CURRENCY_DATA';
+/**
+ *
+ * @param data
+ * @returns {{payload: *, type: *}}
+ */
+export const setCurrencyData = data => ({
+    type: SET_CURRENCY_DATA,
+    payload: data
+});

--- a/src/app/store/Currency/Currency.reducer.js
+++ b/src/app/store/Currency/Currency.reducer.js
@@ -1,0 +1,43 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import { SET_CURRENCY_DATA } from './Currency.action';
+
+/**
+ *
+ * @type {{currency: {}}}
+ */
+export const initialState = {
+    currency: {}
+};
+
+/**
+ *
+ * @param state
+ * @param action
+ * @returns {{currency: *}|{currency: {}}}
+ * @constructor
+ */
+export const CurrencyReducer = (state = initialState, action) => {
+    const { payload, type } = action;
+    switch (type) {
+    case SET_CURRENCY_DATA:
+        return {
+            ...state,
+            currency: payload.currency
+        };
+    default:
+        return state;
+    }
+};
+
+
+export default CurrencyReducer;

--- a/src/app/store/Currency/index.js
+++ b/src/app/store/Currency/index.js
@@ -1,0 +1,12 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+export * from './Currency.action';
+export { default as CurrencyReducer } from './Currency.reducer';

--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -35,6 +35,7 @@ import { OverlayReducer } from 'Store/Overlay';
 import { PopupReducer } from 'Store/Popup';
 import { ConfigReducer } from 'Store/Config';
 import { LinkedProductsReducer } from 'Store/LinkedProducts';
+import { CurrencyReducer } from 'Store/Currency';
 
 export const reducers = {
     CmsBlocksAndSliderReducer,
@@ -58,7 +59,8 @@ export const reducers = {
     PopupReducer,
     UrlRewritesReducer,
     ConfigReducer,
-    LinkedProductsReducer
+    LinkedProductsReducer,
+    CurrencyReducer
 };
 
 const store = createStore(

--- a/src/app/util/Currency/Current.js
+++ b/src/app/util/Currency/Current.js
@@ -1,0 +1,46 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import BrowserDatabase from 'Util/BrowserDatabase';
+
+/**
+ *
+ * @type {string}
+ */
+const CUR_CURRENCY = 'current_currency';
+
+/**
+ *
+ * @type {number}
+ */
+const ONE_HOUR = 3600;
+
+/**
+ *
+ * @param {Any} currency
+ * @returns {void}
+ */
+export const setCurrency = (currency) => {
+    BrowserDatabase.setItem(currency, CUR_CURRENCY, ONE_HOUR);
+};
+
+/**
+ *
+ * @returns {String} currency
+ */
+export const getCurrency = () => {
+    const currency = BrowserDatabase.getItem(CUR_CURRENCY);
+    if (typeof currency === 'string') {
+        return currency;
+    }
+
+    return '';
+};


### PR DESCRIPTION
Fixes issue #433 - Currency Switcher Support in ScandiPwa Store front

## Currency Switcher UI in Header with listing of all available currencies in the store.

Development
1)  Fetches the Currency graphql API and stores in the state and renders which all applicable to display.
2)  When user changes the currency it saves in BrowserStorage and reloads the page, then after reloads the currency will append in request headers of all APIs with new hash.

Test Cases:
1) When currencies count are less then two, then switcher wont display in header.
2) When admin adds new Currency it will show on switcher list. 
3) When admin removes the currency, Then the users which has been set same currency in the BrowserStorage it takes one more reload after fetching the API to clear the currency which are set in BrowserStorage.
4) Changing the currency will reflect in all pages. 