### PR TITLE
Fixed billing address finding logic in checkoutbilling component

### DIFF
--- a/src/app/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.container.js
@@ -166,7 +166,7 @@ export class CheckoutBillingContainer extends PureComponent {
         if (!selectedCustomerAddressId) return trimAddressFields(fields);
 
         const { customer: { addresses } } = this.props;
-        const address = addresses.find(({ id }) => id !== selectedCustomerAddressId);
+        const address = addresses.find(({ id }) => id === selectedCustomerAddressId);
 
         return trimCustomerAddress(address);
     }


### PR DESCRIPTION
Fixes issue #474 

### Manual testing scenarios
1. Signup / Login
2. Add exactly one address to address book (__NOT__ more than one)
3. Add a virtual product to cart
4. Go to checkout
5. Try to proceed with selected billing address (the address previously added)
6. Order should be placed without any errors