### PR TITLE
[SWPWA-375] Terms and conditions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # ScandiPWA Theme
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-31-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=flat-square)](#contributors)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/839cbb593b36432faecd5da0c3844ca8)](https://www.codacy.com/app/ScandiPWA/base-theme?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=scandipwa/base-theme&amp;utm_campaign=Badge_Grade)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fscandipwa%2Fbase-theme.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fscandipwa%2Fbase-theme?ref=badge_shield)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # ScandiPWA Theme
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-31-orange.svg?style=flat-square)](#contributors)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/839cbb593b36432faecd5da0c3844ca8)](https://www.codacy.com/app/ScandiPWA/base-theme?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=scandipwa/base-theme&amp;utm_campaign=Badge_Grade)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fscandipwa%2Fbase-theme.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fscandipwa%2Fbase-theme?ref=badge_shield)
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "scandipwa/reviews-graphql": "^1.0",
         "scandipwa/paypal-graphql": "^1.0",
         "scandipwa/klarna-graphql": "^1.1",
-        "scandipwa/store-graphql": "^1.0.1",
+        "scandipwa/store-graphql": "^1.0.2",
         "scandipwa/customization": "^1.0",
         "scandipwa/cache": "^1.0",
         "scandipwa/locale": "^1.0"

--- a/src/app/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.component.js
@@ -22,26 +22,35 @@ import Field from 'Component/Field';
 
 import './CheckoutBilling.style';
 import { addressType } from 'Type/Account';
+import CheckoutTermsAndConditionsPopup from 'Component/CheckoutTermsAndConditionsPopup';
 
 class CheckoutBilling extends PureComponent {
     state = {
         isOrderButtonVisible: true,
-        isOrderButtonEnabled: true
+        isOrderButtonEnabled: false,
+        termsAndConditionsAccepted: false
     };
 
     static propTypes = {
         setLoading: PropTypes.func.isRequired,
         setDetailsStep: PropTypes.func.isRequired,
         isSameAsShipping: PropTypes.bool.isRequired,
+        termsAreEnabled: PropTypes.bool.isRequired,
         onSameAsShippingChange: PropTypes.func.isRequired,
         onPaymentMethodSelect: PropTypes.func.isRequired,
         onBillingSuccess: PropTypes.func.isRequired,
         onBillingError: PropTypes.func.isRequired,
         onAddressSelect: PropTypes.func.isRequired,
+        showPopup: PropTypes.func.isRequired,
         paymentMethods: paymentMethodsType.isRequired,
         totals: TotalsType.isRequired,
         shippingAddress: addressType.isRequired
     };
+
+    componentDidMount() {
+        const { termsAreEnabled } = this.props;
+        if (!termsAreEnabled) this.setState({ isOrderButtonEnabled: true });
+    }
 
     setOrderButtonVisibility = (isOrderButtonVisible) => {
         this.setState({ isOrderButtonVisible });
@@ -51,9 +60,46 @@ class CheckoutBilling extends PureComponent {
         this.setState({ isOrderButtonEnabled });
     };
 
-    setOrderButtonVisibility = (isOrderButtonVisible) => {
-        this.setState({ isOrderButtonVisible });
+    setTermsAndConfitionsAccepted = () => {
+        this.setState(({ termsAndConditionsAccepted: oldTermsAndConfitionsAccepted }) => ({
+            termsAndConditionsAccepted: !oldTermsAndConfitionsAccepted,
+            isOrderButtonEnabled: !oldTermsAndConfitionsAccepted
+        }));
     };
+
+    handleShowPopup = (e) => {
+        const { showPopup } = this.props;
+        e.preventDefault();
+        showPopup();
+    };
+
+    renderTermsAndConditions() {
+        const { termsAreEnabled } = this.props;
+        const { termsAndConditionsAccepted } = this.state;
+
+        if (!termsAreEnabled) return null;
+
+        return (
+            <>
+                <button
+                  block="CheckoutBilling"
+                  elem="Link"
+                  onClick={ this.handleShowPopup }
+                >
+                    { __('I agree to terms and conditions.') }
+                </button>
+                <Field
+                  id="termsAndConditions"
+                  name="termsAndConditions"
+                  type="checkbox"
+                  value="termsAndConditions"
+                  mix={ { block: 'CheckoutBilling', elem: 'Checkbox' } }
+                  checked={ termsAndConditionsAccepted }
+                  onChange={ this.setTermsAndConfitionsAccepted }
+                />
+            </>
+        );
+    }
 
     renderActions() {
         const { isOrderButtonVisible, isOrderButtonEnabled } = this.state;
@@ -133,6 +179,10 @@ class CheckoutBilling extends PureComponent {
         );
     }
 
+    renderPopup() {
+        return <CheckoutTermsAndConditionsPopup />;
+    }
+
     render() {
         const { onBillingSuccess, onBillingError } = this.props;
 
@@ -145,7 +195,9 @@ class CheckoutBilling extends PureComponent {
             >
                 { this.renderAddresses() }
                 { this.renderPayments() }
+                { this.renderTermsAndConditions() }
                 { this.renderActions() }
+                { this.renderPopup() }
             </Form>
         );
     }

--- a/src/app/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.component.js
@@ -77,26 +77,32 @@ class CheckoutBilling extends PureComponent {
         const { termsAndConditionsAccepted } = this.state;
 
         if (!termsAreEnabled) return null;
+        const spaceSymbol = '\u00A0';
 
         return (
-            <>
-                <button
+            <div
+              block="CheckoutBilling"
+              elem="TermsAndConditions"
+            >
+                { `${__('I agree to') }${ spaceSymbol }` }
+                <label
+                  htmlFor="CheckoutBilling"
                   block="CheckoutBilling"
                   elem="Link"
                   onClick={ this.handleShowPopup }
                 >
-                    { __('I agree to terms and conditions.') }
-                </button>
+                    { __('terms and conditions.') }
+                </label>
                 <Field
                   id="termsAndConditions"
                   name="termsAndConditions"
                   type="checkbox"
                   value="termsAndConditions"
-                  mix={ { block: 'CheckoutBilling', elem: 'Checkbox' } }
+                  mix={ { block: 'CheckoutBilling', elem: 'TermsAndConditions-Checkbox' } }
                   checked={ termsAndConditionsAccepted }
                   onChange={ this.setTermsAndConfitionsAccepted }
                 />
-            </>
+            </div>
         );
     }
 

--- a/src/app/component/CheckoutBilling/CheckoutBilling.component.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.component.js
@@ -12,17 +12,16 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import Form from 'Component/Form';
-import CheckoutPayments from 'Component/CheckoutPayments';
-import CheckoutAddressBook from 'Component/CheckoutAddressBook';
+import CheckoutTermsAndConditionsPopup from 'Component/CheckoutTermsAndConditionsPopup';
 import { BILLING_STEP } from 'Route/Checkout/Checkout.component';
+import CheckoutAddressBook from 'Component/CheckoutAddressBook';
+import CheckoutPayments from 'Component/CheckoutPayments';
 import { paymentMethodsType } from 'Type/Checkout';
 import { TotalsType } from 'Type/MiniCart';
-import Field from 'Component/Field';
-
-import './CheckoutBilling.style';
 import { addressType } from 'Type/Account';
-import CheckoutTermsAndConditionsPopup from 'Component/CheckoutTermsAndConditionsPopup';
+import Field from 'Component/Field';
+import Form from 'Component/Form';
+import './CheckoutBilling.style';
 
 class CheckoutBilling extends PureComponent {
     state = {

--- a/src/app/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.container.js
@@ -35,7 +35,7 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = dispatch => ({
     showErrorNotification: message => dispatch(showNotification('error', message)),
-    showNewPopup: payload => dispatch(showPopup(TERMS_AND_CONDITIONS_POPUP_ID, payload))
+    showPopup: payload => dispatch(showPopup(TERMS_AND_CONDITIONS_POPUP_ID, payload))
 });
 
 export class CheckoutBillingContainer extends PureComponent {
@@ -43,7 +43,7 @@ export class CheckoutBillingContainer extends PureComponent {
         showErrorNotification: PropTypes.func.isRequired,
         paymentMethods: paymentMethodsType.isRequired,
         savePaymentInformation: PropTypes.func.isRequired,
-        showNewPopup: PropTypes.func.isRequired,
+        showPopup: PropTypes.func.isRequired,
         shippingAddress: addressType.isRequired,
         customer: customerType.isRequired,
         totals: TotalsType.isRequired,
@@ -127,13 +127,13 @@ export class CheckoutBillingContainer extends PureComponent {
     }
 
     showPopup() {
-        const { showNewPopup, termsAndConditions } = this.props;
+        const { showPopup, termsAndConditions } = this.props;
         const {
-            checkbox_text: title = 'Terms and Conditions',
-            content: text = 'There are no Terms and Conditions configured.'
+            checkbox_text: title = __('Terms and Conditions'),
+            content: text = __('There are no Terms and Conditions configured.')
         } = termsAndConditions[0] || {};
 
-        return showNewPopup({
+        return showPopup({
             title, text
         });
     }

--- a/src/app/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -13,7 +13,6 @@
     &-Checkbox {
         display: inline-block;
         margin-bottom: 2rem;
-        margin-left: 1rem;
     }
 
     &-Button {
@@ -22,15 +21,29 @@
         }
     }
 
+    &-TermsAndConditions {
+        font-weight: 700;
+        font-size: 1.05rem;
+        margin: 0;
+        margin-bottom: 2rem;
+        display: flex;
+        align-items: center;
+
+        &-Checkbox {
+            margin: 0;
+            margin-left: 1rem;
+        }
+    }
+
     &-Link {
+        color: var(--link-color);
+
         &:hover {
             text-decoration: underline;
         }
-    }
-}
 
-.Button.CheckoutBilling {
-    &-Button {
-        display: block;
+        &:focus {
+            text-decoration: underline;
+        }
     }
 }

--- a/src/app/component/CheckoutBilling/CheckoutBilling.style.scss
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.style.scss
@@ -11,12 +11,26 @@
 
 .CheckoutBilling {
     &-Checkbox {
+        display: inline-block;
         margin-bottom: 2rem;
+        margin-left: 1rem;
     }
 
     &-Button {
         @include mobile {
             width: 100%;
         }
+    }
+
+    &-Link {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+.Button.CheckoutBilling {
+    &-Button {
+        display: block;
     }
 }

--- a/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
@@ -1,0 +1,52 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Popup from 'Component/Popup';
+import './CheckoutTermsAndConditionsPopup.style';
+import Loader from 'Component/Loader';
+import Html from 'Component/Html';
+
+export const TERMS_AND_CONDITIONS_POPUP_ID = 'CheckoutTermsAndConditionsPopup';
+
+class CheckoutTermsAndConditionsPopup extends PureComponent {
+    static propTypes = {
+        isLoading: PropTypes.bool.isRequired,
+        payload: PropTypes.shape({
+            text: PropTypes.string
+        }).isRequired
+    };
+
+    renderContent() {
+        const { payload: { text = 'No text was passed' } } = this.props;
+        return (
+            <Html content={ text } />
+        );
+    }
+
+    render() {
+        const { isLoading } = this.props;
+
+        return (
+            <Popup
+              id={ TERMS_AND_CONDITIONS_POPUP_ID }
+              clickOutside={ false }
+              mix={ { block: 'CheckoutTermsAndConditionsPopup' } }
+            >
+                <Loader isLoading={ isLoading } />
+                { this.renderContent() }
+            </Popup>
+        );
+    }
+}
+
+export default CheckoutTermsAndConditionsPopup;

--- a/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.component.js
@@ -13,14 +13,12 @@ import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Popup from 'Component/Popup';
 import './CheckoutTermsAndConditionsPopup.style';
-import Loader from 'Component/Loader';
 import Html from 'Component/Html';
 
 export const TERMS_AND_CONDITIONS_POPUP_ID = 'CheckoutTermsAndConditionsPopup';
 
 class CheckoutTermsAndConditionsPopup extends PureComponent {
     static propTypes = {
-        isLoading: PropTypes.bool.isRequired,
         payload: PropTypes.shape({
             text: PropTypes.string
         }).isRequired
@@ -34,15 +32,12 @@ class CheckoutTermsAndConditionsPopup extends PureComponent {
     }
 
     render() {
-        const { isLoading } = this.props;
-
         return (
             <Popup
               id={ TERMS_AND_CONDITIONS_POPUP_ID }
               clickOutside={ false }
               mix={ { block: 'CheckoutTermsAndConditionsPopup' } }
             >
-                <Loader isLoading={ isLoading } />
                 { this.renderContent() }
             </Popup>
         );

--- a/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.container.js
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.container.js
@@ -13,8 +13,6 @@ import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { hideActiveOverlay } from 'Store/Overlay';
-
 import CheckoutTermsAndConditionsPopup, {
     TERMS_AND_CONDITIONS_POPUP_ID
 } from './CheckoutTermsAndConditionsPopup.component';
@@ -23,13 +21,8 @@ export const mapStateToProps = state => ({
     payload: state.PopupReducer.popupPayload[TERMS_AND_CONDITIONS_POPUP_ID] || {}
 });
 
-export const mapDispatchToProps = dispatch => ({
-    hideActiveOverlay: () => dispatch(hideActiveOverlay())
-});
-
 export class CheckoutTermsAndConditionsPopupContainer extends PureComponent {
     static propTypes = {
-        hideActiveOverlay: PropTypes.func.isRequired,
         payload: PropTypes.shape({
             text: PropTypes.string
         })
@@ -41,27 +34,14 @@ export class CheckoutTermsAndConditionsPopupContainer extends PureComponent {
         }
     };
 
-    state = {
-        isLoading: false
-    };
-
-    handleAfterAction = () => {
-        const {
-            hideActiveOverlay
-        } = this.props;
-
-        this.setState({ isLoading: false }, () => hideActiveOverlay());
-    };
-
     render() {
         return (
             <CheckoutTermsAndConditionsPopup
               { ...this.props }
-              { ...this.state }
               { ...this.containerFunctions }
             />
         );
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CheckoutTermsAndConditionsPopupContainer);
+export default connect(mapStateToProps)(CheckoutTermsAndConditionsPopupContainer);

--- a/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.container.js
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.container.js
@@ -1,0 +1,67 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { hideActiveOverlay } from 'Store/Overlay';
+
+import CheckoutTermsAndConditionsPopup, {
+    TERMS_AND_CONDITIONS_POPUP_ID
+} from './CheckoutTermsAndConditionsPopup.component';
+
+export const mapStateToProps = state => ({
+    payload: state.PopupReducer.popupPayload[TERMS_AND_CONDITIONS_POPUP_ID] || {}
+});
+
+export const mapDispatchToProps = dispatch => ({
+    hideActiveOverlay: () => dispatch(hideActiveOverlay())
+});
+
+export class CheckoutTermsAndConditionsPopupContainer extends PureComponent {
+    static propTypes = {
+        hideActiveOverlay: PropTypes.func.isRequired,
+        payload: PropTypes.shape({
+            text: PropTypes.string
+        })
+    };
+
+    static defaultProps = {
+        payload: {
+            text: ''
+        }
+    };
+
+    state = {
+        isLoading: false
+    };
+
+    handleAfterAction = () => {
+        const {
+            hideActiveOverlay
+        } = this.props;
+
+        this.setState({ isLoading: false }, () => hideActiveOverlay());
+    };
+
+    render() {
+        return (
+            <CheckoutTermsAndConditionsPopup
+              { ...this.props }
+              { ...this.state }
+              { ...this.containerFunctions }
+            />
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CheckoutTermsAndConditionsPopupContainer);

--- a/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.style.scss
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/CheckoutTermsAndConditionsPopup.style.scss
@@ -1,0 +1,16 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+.CheckoutTermsAndConditionsPopup {
+    &-Address {
+        margin: 1rem 0;
+    }
+}

--- a/src/app/component/CheckoutTermsAndConditionsPopup/index.js
+++ b/src/app/component/CheckoutTermsAndConditionsPopup/index.js
@@ -1,0 +1,12 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+export { default } from './CheckoutTermsAndConditionsPopup.container';

--- a/src/app/query/Config.query.js
+++ b/src/app/query/Config.query.js
@@ -17,6 +17,24 @@ export class ConfigQuery {
             .addFieldList(this._getStoreListFields());
     }
 
+    getCheckoutAgreements() {
+        return new Field('checkoutAgreements')
+            .addFieldList(this._getCheckoutAgreementFields());
+    }
+
+    _getCheckoutAgreementFields() {
+        return [
+            'agreement_id',
+            'checkbox_text',
+            'content',
+            'content_height',
+            'is_html',
+            'mode',
+            'name'
+        ];
+    }
+
+
     _getStoreListFields() {
         return [
             'name',
@@ -46,7 +64,8 @@ export class ConfigQuery {
                 'secure_base_media_url',
                 'paypal_sandbox_flag',
                 'paypal_client_id',
-                'logo_alt'
+                'logo_alt',
+                'terms_are_enabled'
             ]);
     }
 }

--- a/src/app/store/Config/Config.dispatcher.js
+++ b/src/app/store/Config/Config.dispatcher.js
@@ -36,7 +36,8 @@ export class ConfigDispatcher extends QueryDispatcher {
         return [
             RegionQuery.getCountriesQuery(),
             ReviewQuery.getRatingQuery(),
-            ConfigQuery.getQuery()
+            ConfigQuery.getQuery(),
+            ConfigQuery.getCheckoutAgreements()
         ];
     }
 }

--- a/src/app/store/Config/Config.reducer.js
+++ b/src/app/store/Config/Config.reducer.js
@@ -35,21 +35,27 @@ export const initialState = {
 };
 
 const ConfigReducer = (state = initialState, action) => {
-    const { config: { countries, reviewRatings, storeConfig = {} } = {}, type } = action;
+    const {
+        config: {
+            countries, reviewRatings, checkoutAgreements, storeConfig = {}
+        } = {}, type
+    } = action;
 
     switch (type) {
     case UPDATE_CONFIG:
         const filteredStoreConfig = filterStoreConfig(storeConfig);
-        const { header_logo_src } = filteredStoreConfig;
+        const { header_logo_src, terms_are_enabled = false } = filteredStoreConfig;
 
         return {
             ...state,
             countries,
             reviewRatings,
+            checkoutAgreements,
             ...filteredStoreConfig,
             // Should be updated manually as filteredStoreConfig does not contain header_logo_src when it is null
             // and header_logo_src takes old value
             header_logo_src,
+            terms_are_enabled,
             isLoading: false
         };
 

--- a/src/app/store/Config/Config.reducer.js
+++ b/src/app/store/Config/Config.reducer.js
@@ -37,7 +37,10 @@ export const initialState = {
 const ConfigReducer = (state = initialState, action) => {
     const {
         config: {
-            countries, reviewRatings, checkoutAgreements, storeConfig = {}
+            countries,
+            reviewRatings,
+            checkoutAgreements,
+            storeConfig = {}
         } = {}, type
     } = action;
 

--- a/src/app/style/base/_link.scss
+++ b/src/app/style/base/_link.scss
@@ -8,11 +8,12 @@
  * @package scandipwa/base-theme
  * @link https://github.com/scandipwa/base-theme
  */
-
-a {
+:root {
     --link-color: var(--primary-base-color);
     --link-hover: var(--primary-dark-color);
+}
 
+a {
     color: var(--link-color);
 
     &:hover {


### PR DESCRIPTION
* Added terms and conditions to config store
* Added `TermsAndConditionsPopup` component
* Added support for terms and conditions on checkout step

Depends on https://github.com/scandipwa/store-graphql/pull/1

Screens:
Terms and conditions are Enabled:
![Selection_080](https://user-images.githubusercontent.com/53301511/71587286-c3facf80-2b25-11ea-8a6f-979927e33ea7.png)
![Selection_081](https://user-images.githubusercontent.com/53301511/71587289-c5c49300-2b25-11ea-9b08-4d42d9da0cba.png)
* Popup with Terms and Conditions:
![Selection_082](https://user-images.githubusercontent.com/53301511/71587291-c78e5680-2b25-11ea-8026-ff25e3728c2b.png)

Terms and conditions are disabled:
![Selection_083](https://user-images.githubusercontent.com/53301511/71587336-eee52380-2b25-11ea-987c-1211b4067725.png)
