### PR TITLE
[SWPWA-387] Always show layered navigation on PLP with products

### DIFF
--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -47,6 +47,8 @@ export default class CategoryFilterOverlay extends PureComponent {
         const min = minValue || minPriceValue;
         const max = maxValue || maxPriceValue;
 
+        if (maxPriceValue - minPriceValue === 0) return null;
+
         return (
             <ExpandableContent
               heading={ __('Price') }
@@ -126,7 +128,11 @@ export default class CategoryFilterOverlay extends PureComponent {
                 || !Object.keys(availableFilters).length
             )
         ) {
-            return <div block="CategoryFilterOverlay" />;
+            return (
+                <Overlay mix={ { block: 'CategoryFilterOverlay' } } id="category-filter">
+                    { this.renderPriceRange() }
+                </Overlay>
+            );
         }
 
         return (


### PR DESCRIPTION
Layered navigation has the following behaviour now:
* Collection of non-configurable products - show price slider
![Selection_107](https://user-images.githubusercontent.com/53301511/72340492-f8978b00-36d0-11ea-9f67-f7e92f22ea19.png)
* Collection of non-configurable products with the same price - no layered navigation
![Selection_108](https://user-images.githubusercontent.com/53301511/72340716-55934100-36d1-11ea-8164-701d326eaca4.png)
* Empty collection - no layered navigation
![Selection_109](https://user-images.githubusercontent.com/53301511/72340765-6c399800-36d1-11ea-9074-f639aab1dc99.png)