### PR TITLE
[SWPWA-385] fix attributes are not respecting attribute values

### DIFF
--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -26,7 +26,7 @@ export default class ProductAttributeValue extends PureComponent {
         isSelected: PropTypes.bool,
         isAvailable: PropTypes.bool,
         mix: MixType,
-        formatAsText: PropTypes.bool
+        isFormattedAsText: PropTypes.bool
     };
 
     static defaultProps = {
@@ -35,7 +35,7 @@ export default class ProductAttributeValue extends PureComponent {
         getLink: () => {},
         mix: {},
         isAvailable: true,
-        formatAsText: false
+        isFormattedAsText: false
     };
 
     clickHandler = this.clickHandler.bind(this);
@@ -121,10 +121,10 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderColorValue(color, label) {
-        const { formatAsText, isSelected } = this.props;
+        const { isFormattedAsText, isSelected } = this.props;
         const isLight = this.getIsColorLight(color);
 
-        if (formatAsText) return label || __('N/A');
+        if (isFormattedAsText) return label || __('N/A');
 
         return (
             <data
@@ -143,9 +143,9 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderImageValue(img, label) {
-        const { formatAsText, isSelected } = this.props;
+        const { isFormattedAsText, isSelected } = this.props;
 
-        if (formatAsText) return label || __('N/A');
+        if (isFormattedAsText) return label || __('N/A');
         return (
             <>
                 <img
@@ -188,10 +188,10 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderStringValue(value, label) {
-        const { formatAsText, isSelected } = this.props;
+        const { isFormattedAsText, isSelected } = this.props;
         const isSwatch = label;
 
-        if (formatAsText) return label || value || __('N/A');
+        if (isFormattedAsText) return label || value || __('N/A');
 
         if (!isSwatch) return this.renderDropdown(value);
 
@@ -231,7 +231,7 @@ export default class ProductAttributeValue extends PureComponent {
             isAvailable,
             attribute: { attribute_code, attribute_value },
             mix,
-            formatAsText
+            isFormattedAsText
         } = this.props;
 
         if (attribute_code && !attribute_value) return null;
@@ -240,7 +240,7 @@ export default class ProductAttributeValue extends PureComponent {
         // Invert to apply css rule without using not()
         const isNotAvailable = !isAvailable;
 
-        if (formatAsText) {
+        if (isFormattedAsText) {
             return (
                 <div
                   block="ProductAttributeValue"

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -20,17 +20,22 @@ import './ProductAttributeValue.style';
 
 export default class ProductAttributeValue extends PureComponent {
     static propTypes = {
-        getLink: PropTypes.func.isRequired,
-        onClick: PropTypes.func.isRequired,
+        getLink: PropTypes.func,
+        onClick: PropTypes.func,
         attribute: AttributeType.isRequired,
         isSelected: PropTypes.bool,
-        isAvailable: PropTypes.bool.isRequired,
-        mix: MixType
+        isAvailable: PropTypes.bool,
+        mix: MixType,
+        formatAsText: PropTypes.bool
     };
 
     static defaultProps = {
         isSelected: false,
-        mix: {}
+        onClick: () => {},
+        getLink: () => {},
+        mix: {},
+        isAvailable: true,
+        formatAsText: false
     };
 
     clickHandler = this.clickHandler.bind(this);
@@ -116,8 +121,10 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderColorValue(color, label) {
-        const { isSelected } = this.props;
+        const { formatAsText, isSelected } = this.props;
         const isLight = this.getIsColorLight(color);
+
+        if (formatAsText) return label || __('N/A');
 
         return (
             <data
@@ -136,8 +143,9 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderImageValue(img, label) {
-        const { isSelected } = this.props;
+        const { formatAsText, isSelected } = this.props;
 
+        if (formatAsText) return label || __('N/A');
         return (
             <>
                 <img
@@ -180,8 +188,10 @@ export default class ProductAttributeValue extends PureComponent {
     }
 
     renderStringValue(value, label) {
-        const { isSelected } = this.props;
+        const { formatAsText, isSelected } = this.props;
         const isSwatch = label;
+
+        if (formatAsText) return label || value || __('N/A');
 
         if (!isSwatch) return this.renderDropdown(value);
 
@@ -220,7 +230,8 @@ export default class ProductAttributeValue extends PureComponent {
             attribute,
             isAvailable,
             attribute: { attribute_code, attribute_value },
-            mix
+            mix,
+            formatAsText
         } = this.props;
 
         if (attribute_code && !attribute_value) return null;
@@ -228,6 +239,18 @@ export default class ProductAttributeValue extends PureComponent {
         const href = getLink(attribute);
         // Invert to apply css rule without using not()
         const isNotAvailable = !isAvailable;
+
+        if (formatAsText) {
+            return (
+                <div
+                  block="ProductAttributeValue"
+                  aria-hidden={ isNotAvailable }
+                  mix={ mix }
+                >
+                    { this.renderAttributeByType() }
+                </div>
+            );
+        }
 
         return (
             <a

--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -244,7 +244,6 @@ export default class ProductAttributeValue extends PureComponent {
             return (
                 <div
                   block="ProductAttributeValue"
-                  aria-hidden={ isNotAvailable }
                   mix={ mix }
                 >
                     { this.renderAttributeByType() }

--- a/src/app/component/ProductCard/ProductCard.component.js
+++ b/src/app/component/ProductCard/ProductCard.component.js
@@ -141,7 +141,7 @@ export default class ProductCard extends PureComponent {
             >
                 <ProductAttributeValue
                   attribute={ brand }
-                  formatAsText
+                  isFormattedAsText
                 />
             </div>
         );

--- a/src/app/component/ProductCard/ProductCard.component.js
+++ b/src/app/component/ProductCard/ProductCard.component.js
@@ -12,7 +12,6 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import media, { PRODUCT_MEDIA } from 'Util/Media';
 import Link from 'Component/Link';
 import Image from 'Component/Image';
 import Loader from 'Component/Loader';
@@ -20,6 +19,7 @@ import { ProductType } from 'Type/ProductList';
 import ProductPrice from 'Component/ProductPrice';
 import TextPlaceholder from 'Component/TextPlaceholder';
 import ProductReviewRating from 'Component/ProductReviewRating';
+import ProductAttributeValue from 'Component/ProductAttributeValue';
 
 import './ProductCard.style';
 
@@ -128,19 +128,22 @@ export default class ProductCard extends PureComponent {
     renderAdditionalProductDetails() {
         const { product: { sku }, getAttribute } = this.props;
         const { product_list_content: { attribute_to_display } = {} } = window.contentConfiguration;
-        const { attribute_value: brand } = getAttribute(attribute_to_display || 'brand') || {};
+        const brand = getAttribute(attribute_to_display || 'brand') || {};
 
         if (sku && !brand) return null;
 
         return (
-            <p
+            <div
               block="ProductCard"
               elem="Brand"
               mods={ { isLoaded: !!brand } }
               itemProp="brand"
             >
-                { brand }
-            </p>
+                <ProductAttributeValue
+                  attribute={ brand }
+                  formatAsText
+                />
+            </div>
         );
     }
 

--- a/src/app/component/ProductCard/ProductCard.container.js
+++ b/src/app/component/ProductCard/ProductCard.container.js
@@ -37,7 +37,7 @@ export class ProductCardContainer extends PureComponent {
     };
 
     getAttribute(code) {
-        const { product: { attributes = [] } } = this.props;
+        const { product: { attributes = {} } } = this.props;
         return attributes[code];
     }
 

--- a/src/app/component/ProductInformation/ProductInformation.component.js
+++ b/src/app/component/ProductInformation/ProductInformation.component.js
@@ -15,10 +15,11 @@ import PropTypes from 'prop-types';
 import media, { PRODUCT_MEDIA } from 'Util/Media';
 import Html from 'Component/Html';
 import Image from 'Component/Image';
-import { ProductType } from 'Type/ProductList';
+import { ProductType, AttributeType } from 'Type/ProductList';
 import ContentWrapper from 'Component/ContentWrapper';
 import TextPlaceholder from 'Component/TextPlaceholder';
 import ExpandableContent from 'Component/ExpandableContent';
+import ProductAttributeValue from 'Component/ProductAttributeValue';
 
 import './ProductInformation.style';
 
@@ -26,7 +27,7 @@ export default class ProductInformation extends PureComponent {
     static propTypes = {
         product: ProductType.isRequired,
         areDetailsLoaded: PropTypes.bool.isRequired,
-        attributesWithValues: PropTypes.objectOf(PropTypes.string).isRequired
+        attributesWithValues: AttributeType.isRequired
     };
 
     renderContentPlaceholder() {
@@ -58,7 +59,11 @@ export default class ProductInformation extends PureComponent {
                 { attributeLabel }
             </dt>
             <dd block="ProductInformation" elem="ValueLabel">
-                { valueLabel }
+                <ProductAttributeValue
+                  key={ attributeLabel }
+                  attribute={ valueLabel }
+                  formatAsText
+                />
             </dd>
         </Fragment>
     );

--- a/src/app/component/ProductInformation/ProductInformation.component.js
+++ b/src/app/component/ProductInformation/ProductInformation.component.js
@@ -62,7 +62,7 @@ export default class ProductInformation extends PureComponent {
                 <ProductAttributeValue
                   key={ attributeLabel }
                   attribute={ valueLabel }
-                  formatAsText
+                  isFormattedAsText
                 />
             </dd>
         </Fragment>

--- a/src/app/component/ProductInformation/ProductInformation.container.js
+++ b/src/app/component/ProductInformation/ProductInformation.container.js
@@ -26,13 +26,12 @@ export default class ProductInformationContainer extends PureComponent {
         const { product: { attributes = {}, parameters = {} } } = this.props;
 
         const allAttribsWithValues = Object.entries(attributes).reduce((acc, [key, val]) => {
-            const { attribute_label, attribute_options, attribute_value } = val;
-            if (attribute_value) return { ...acc, [attribute_label]: attribute_value };
+            const { attribute_label, attribute_value } = val;
+            if (attribute_value) return { ...acc, [attribute_label]: val };
 
             const valueIndexFromParameter = parameters[key];
             if (valueIndexFromParameter) {
-                const { label } = attribute_options[valueIndexFromParameter];
-                return { ...acc, [attribute_label]: label };
+                return { ...acc, [attribute_label]: { ...val, attribute_value: valueIndexFromParameter } };
             }
 
             return acc;


### PR DESCRIPTION
* Adjusted `ProductAttributeValue` component, now it return text value of attribute when `formatAsText` prop is passed. Handles all types of attributes, e.g. swatches, multiselects, dropdowns, yes/no, text.
* Integrated this component into `ProductInformationComponent` and `ProductCardComponent`. Now attribute values are being displayed correctly.

Examples:
* Text attribute
![Selection_110](https://user-images.githubusercontent.com/53301511/72356949-d1ea4c00-36f2-11ea-9826-5db665cd87af.png)
* Swatch
![Selection_111](https://user-images.githubusercontent.com/53301511/72356974-d9115a00-36f2-11ea-96ea-55833c57eb14.png)
* Multiselect
![Selection_112](https://user-images.githubusercontent.com/53301511/72357003-ea5a6680-36f2-11ea-9bac-97c8980fe4b2.png)
