### PR TITLE
[SWPWA-407] Remove attribute placeholders in search

### DIFF
--- a/src/app/component/SearchOverlay/SearchOverlay.component.js
+++ b/src/app/component/SearchOverlay/SearchOverlay.component.js
@@ -54,12 +54,21 @@ export default class SearchOverlay extends PureComponent {
         }
     }
 
+    renderSearchItemAdditionalContent(brand) {
+        const { isLoading } = this.props;
+        if (!isLoading && !brand) return null;
+
+        return (
+            <p block="SearchOverlay" elem="Brand">
+                <TextPlaceholder content={ brand } />
+            </p>
+        );
+    }
+
     renderSearchItemContent(name, brand) {
         return (
             <>
-                <p block="SearchOverlay" elem="Brand">
-                    <TextPlaceholder content={ brand } />
-                </p>
+                { this.renderSearchItemAdditionalContent(brand) }
                 <h4 block="SearchOverlay" elem="Title" mods={ { isLoaded: !!name } }>
                     <TextPlaceholder content={ name } length="long" />
                 </h4>


### PR DESCRIPTION
Removed attribute placeholder in search when attribute is undefined.

Example (1st product has no placeholder for `brand` anymore):
![Selection_164](https://user-images.githubusercontent.com/53301511/73123458-da674000-3f98-11ea-937a-471b12ab5435.png)
