### PR TITLE
[BugSheet] Fixed queryHash generation.

### DIFF
--- a/src/app/util/Request/DataContainer.js
+++ b/src/app/util/Request/DataContainer.js
@@ -28,7 +28,7 @@ export class DataContainer extends PureComponent {
     fetchData(rawQueries, onSucces = () => {}, onError = () => {}) {
         const preparedQuery = prepareQuery(rawQueries);
         const { query, variables } = preparedQuery;
-        const queryHash = hash(query + variables);
+        const queryHash = hash(query + JSON.stringify(variables));
 
         if (!window.dataCache) {
             window.dataCache = {};


### PR DESCRIPTION
Fixed `queryHash` generation.
Before the same queries with different variables received similar hash.