### PR TITLE
[SWPWA-387|FIX] Always show layered navigation on PLP with products

### DIFF
--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -18,6 +18,8 @@ import ExpandableContent from 'Component/ExpandableContent';
 import CategoryConfigurableAttributes from 'Component/CategoryConfigurableAttributes';
 import './CategoryFilterOverlay.style';
 
+export const CATEGORY_FILTER_OVERLAY_ID = 'category-filter';
+
 export default class CategoryFilterOverlay extends PureComponent {
     static propTypes = {
         availableFilters: PropTypes.objectOf(PropTypes.shape).isRequired,
@@ -137,7 +139,7 @@ export default class CategoryFilterOverlay extends PureComponent {
             return (
                 <Overlay
                   mix={ { block: 'CategoryFilterOverlay' } }
-                  id="category-filter"
+                  id={ CATEGORY_FILTER_OVERLAY_ID }
                 />
             );
         }
@@ -150,7 +152,7 @@ export default class CategoryFilterOverlay extends PureComponent {
             )
         ) {
             return (
-                <Overlay mix={ { block: 'CategoryFilterOverlay' } } id="category-filter">
+                <Overlay mix={ { block: 'CategoryFilterOverlay' } } id={ CATEGORY_FILTER_OVERLAY_ID }>
                     { this.renderPriceRange() }
                 </Overlay>
             );
@@ -160,7 +162,7 @@ export default class CategoryFilterOverlay extends PureComponent {
             <Overlay
               onVisible={ onVisible }
               mix={ { block: 'CategoryFilterOverlay' } }
-              id="category-filter"
+              id={ CATEGORY_FILTER_OVERLAY_ID }
             >
                 { this.renderHeading() }
                 { this.renderResetButton() }

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -33,7 +33,8 @@ export default class CategoryFilterOverlay extends PureComponent {
         onVisible: PropTypes.func.isRequired,
         customFiltersValues: PropTypes.objectOf(PropTypes.array).isRequired,
         toggleCustomFilter: PropTypes.func.isRequired,
-        getFilterUrl: PropTypes.func.isRequired
+        getFilterUrl: PropTypes.func.isRequired,
+        totalPages: PropTypes.number.isRequired
     };
 
     renderPriceRange() {
@@ -48,7 +49,7 @@ export default class CategoryFilterOverlay extends PureComponent {
         const min = minValue || minPriceValue;
         const max = maxValue || maxPriceValue;
 
-        if (maxPriceValue - minPriceValue === 0) return null;
+        if (maxPriceValue - minPriceValue <= 1) return null;
 
         return (
             <ExpandableContent
@@ -128,8 +129,11 @@ export default class CategoryFilterOverlay extends PureComponent {
         const {
             isInfoLoading,
             availableFilters,
+            totalPages,
             onVisible
         } = this.props;
+
+        if (totalPages === 0) return null;
 
         if (
             !isInfoLoading

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -49,7 +49,7 @@ export default class CategoryFilterOverlay extends PureComponent {
         const min = minValue || minPriceValue;
         const max = maxValue || maxPriceValue;
 
-        if (maxPriceValue - minPriceValue <= 1) return null;
+        if (maxPriceValue - minPriceValue === 0) return null;
 
         return (
             <ExpandableContent
@@ -133,7 +133,7 @@ export default class CategoryFilterOverlay extends PureComponent {
             onVisible
         } = this.props;
 
-        if (totalPages === 0) return null;
+        if (totalPages === 0) return <Overlay mix={ { block: 'CategoryFilterOverlay' } } id="category-filter" />;
 
         if (
             !isInfoLoading

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -133,7 +133,14 @@ export default class CategoryFilterOverlay extends PureComponent {
             onVisible
         } = this.props;
 
-        if (totalPages === 0) return <Overlay mix={ { block: 'CategoryFilterOverlay' } } id="category-filter" />;
+        if (totalPages === 0) {
+            return (
+                <Overlay
+                  mix={ { block: 'CategoryFilterOverlay' } }
+                  id="category-filter"
+                />
+            );
+        }
 
         if (
             !isInfoLoading

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
@@ -21,7 +21,8 @@ import { FILTER } from 'Component/Header';
 import CategoryFilterOverlay from './CategoryFilterOverlay.component';
 
 export const mapStateToProps = state => ({
-    isInfoLoading: state.ProductListInfoReducer.isLoading
+    isInfoLoading: state.ProductListInfoReducer.isLoading,
+    totalPages: state.ProductListReducer.totalPages
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/app/route/CategoryPage/CategoryPage.component.js
+++ b/src/app/route/CategoryPage/CategoryPage.component.js
@@ -11,6 +11,9 @@
 
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import {
+    CATEGORY_FILTER_OVERLAY_ID
+} from 'Component/CategoryFilterOverlay/CategoryFilterOverlay.component';
 import CategoryFilterOverlay from 'Component/CategoryFilterOverlay';
 import CategoryProductList from 'Component/CategoryProductList';
 import CategoryItemsCount from 'Component/CategoryItemsCount';
@@ -58,7 +61,7 @@ export default class CategoryPage extends PureComponent {
 
     onFilterButtonClick() {
         const { toggleOverlayByKey } = this.props;
-        toggleOverlayByKey('category-filter');
+        toggleOverlayByKey(CATEGORY_FILTER_OVERLAY_ID);
     }
 
     renderCategoryDetails() {


### PR DESCRIPTION
Behaviour:
* No products - no filters and no price range
![Selection_171](https://user-images.githubusercontent.com/53301511/73294222-0f2ffd00-420e-11ea-86fc-f9a721b99640.png)
* Only products with no attributes - no filters, only price range
![Selection_174](https://user-images.githubusercontent.com/53301511/73294288-37b7f700-420e-11ea-9fe5-a0ecc6a62983.png)
![Selection_173](https://user-images.githubusercontent.com/53301511/73294300-3be41480-420e-11ea-8fb4-4cead0d65a1e.png)
