### PR TITLE
remove redundant state

### DIFF
--- a/src/app/route/ProductPage/ProductPage.container.js
+++ b/src/app/route/ProductPage/ProductPage.container.js
@@ -65,7 +65,6 @@ export class ProductPageContainer extends PureComponent {
 
     state = {
         configurableVariantIndex: -1,
-        isConfigurationInitialized: false,
         parameters: {}
     };
 
@@ -246,7 +245,6 @@ export class ProductPageContainer extends PureComponent {
             }
         };
 
-        this.setState({ isConfigurationInitialized: false });
         requestProduct(options);
     }
 


### PR DESCRIPTION
`isConfigurationInitialized` is not used anywhere, therefore it should be removed