### PR TITLE
SWPWA-405 - Special price does not disappear

### DIFF
--- a/src/app/query/ProductList.query.js
+++ b/src/app/query/ProductList.query.js
@@ -130,6 +130,8 @@ export class ProductListQuery {
             this._getProductThumbnailField(),
             this._getProductSmallField(),
             this._getShortDescriptionField(),
+            'special_from_date',
+            'special_to_date',
             this._getAttributesField(isVariant),
             ...(!isVariant
                 ? [

--- a/src/app/type/ProductList.js
+++ b/src/app/type/ProductList.js
@@ -116,6 +116,8 @@ export const ProductType = PropTypes.shape({
     small_image: PropTypes.shape({ url: PropTypes.string }),
     small_image_label: PropTypes.shape({ label: PropTypes.string }),
     special_price: PropTypes.number,
+    special_from_date: PropTypes.string,
+    special_to_date: PropTypes.string,
     thumbnail: PropTypes.shape({ url: PropTypes.string }),
     thumbnail_label: PropTypes.shape({ label: PropTypes.string }),
     tier_prices: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
Special price does not disappear after the time of the promotion ends. By adding special_from_date and special_to_date fields to the query - issue gets fixed, the special price is not showing anymore if time has ended.