### PR TITLE
[SWPWA-470] Product Markup / Configurable - Structured Data markup adjustments

### DIFF
--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -291,6 +291,7 @@ export default class ProductActions extends PureComponent {
 
         return (
             <ProductPrice
+              isSchemaRequired
               price={ productOrVariantPrice }
               mix={ { block: 'ProductActions', elem: 'Price' } }
             />

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -96,6 +96,12 @@ export default class ProductActions extends PureComponent {
         }
     };
 
+    renderStock(stockStatus) {
+        return (
+            (stockStatus === 'OUT_OF_STOCK') ? __('Out of stock') : __('In stock')
+        );
+    }
+
     renderSkuAndStock() {
         const {
             product,
@@ -125,7 +131,7 @@ export default class ProductActions extends PureComponent {
                                 { `SKU: ${ sku }` }
                             </span>
                             <span block="ProductActions" elem="Stock">
-                                { (stock_status === 'OUT_OF_STOCK') ? __('Out of stock') : __('In stock') }
+                                { this.renderStock(stock_status) }
                             </span>
                         </>
                     ),
@@ -278,23 +284,66 @@ export default class ProductActions extends PureComponent {
         );
     }
 
-    renderPrice() {
-        const { product: { price, variants, type_id }, configurableVariantIndex } = this.props;
+    renderSchema(name, stockStatus) {
+        const { getLink } = this.props;
+        return (
+            <>
+                <meta itemProp="offerCount" content={ 1 } />
+                <meta itemProp="availability" content={ this.renderStock(stockStatus) } />
+                <a
+                  block="ProductActions"
+                  elem="Schema-Url"
+                  itemProp="url"
+                  href={ getLink() }
+                >
+                    { name }
+                </a>
+            </>
+        );
+    }
 
-        if (type_id === GROUPED) return null;
+    renderPriceWithSchema() {
+        const {
+            product,
+            product: { variants },
+            configurableVariantIndex
+        } = this.props;
 
         // Product in props is updated before ConfigurableVariantIndex in props, when page is opened by clicking CartItem
         // As a result, we have new product, but old configurableVariantIndex, which may be out of range for variants
-        const productOrVariantPrice = variants && variants[configurableVariantIndex] !== undefined
-            ? variants[configurableVariantIndex].price
-            : price;
+        const productOrVariant = variants && variants[configurableVariantIndex] !== undefined
+            ? variants[configurableVariantIndex]
+            : product;
+
+        const { name, price, stock_status } = productOrVariant;
 
         return (
-            <ProductPrice
-              isSchemaRequired
-              price={ productOrVariantPrice }
-              mix={ { block: 'ProductActions', elem: 'Price' } }
-            />
+            <div>
+                { this.renderSchema(name, stock_status) }
+                <ProductPrice
+                  isSchemaRequired
+                  price={ price }
+                  mix={ { block: 'ProductActions', elem: 'Price' } }
+                />
+            </div>
+        );
+    }
+
+    renderPriceWithGlobalSchema() {
+        const { product: { type_id } } = this.props;
+
+        if (type_id === GROUPED) return null;
+
+        return (
+            <div
+              block="ProductActions"
+              elem="Schema"
+              itemType="https://schema.org/AggregateOffer"
+              itemProp="offers"
+              itemScope
+            >
+                { this.renderPriceWithSchema() }
+            </div>
         );
     }
 
@@ -318,13 +367,16 @@ export default class ProductActions extends PureComponent {
     renderReviews() {
         const { product: { review_summary: { rating_summary, review_count } = {} } } = this.props;
 
-        if (!rating_summary) return null;
+        if (!rating_summary) return 'null';
 
         const ONE_FIFTH_OF_A_HUNDRED = 20;
         const rating = parseFloat(rating_summary / ONE_FIFTH_OF_A_HUNDRED).toFixed(2);
 
         return (
-            <div block="ProductActions" elem="Reviews">
+            <div
+              block="ProductActions"
+              elem="Reviews"
+            >
                 <ProductReviewRating summary={ rating_summary || 0 } />
                 <p block="ProductActions" elem="ReviewLabel">
                     { rating }
@@ -374,7 +426,7 @@ export default class ProductActions extends PureComponent {
     render() {
         return (
             <article block="ProductActions">
-                { this.renderPrice() }
+                { this.renderPriceWithGlobalSchema() }
                 { this.renderShortDescription() }
                 <div block="ProductActions" elem="AddToCartWrapper">
                     { this.renderQuantityInput() }

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -285,10 +285,11 @@ export default class ProductActions extends PureComponent {
     }
 
     renderSchema(name, stockStatus) {
-        const { getLink } = this.props;
+        const { getLink, product: { variants } } = this.props;
+
         return (
             <>
-                <meta itemProp="offerCount" content={ 1 } />
+                <meta itemProp="offerCount" content={ variants.length } />
                 <meta itemProp="availability" content={ this.renderStock(stockStatus) } />
                 <a
                   block="ProductActions"

--- a/src/app/component/ProductActions/ProductActions.component.js
+++ b/src/app/component/ProductActions/ProductActions.component.js
@@ -367,7 +367,7 @@ export default class ProductActions extends PureComponent {
     renderReviews() {
         const { product: { review_summary: { rating_summary, review_count } = {} } } = this.props;
 
-        if (!rating_summary) return 'null';
+        if (!rating_summary) return null;
 
         const ONE_FIFTH_OF_A_HUNDRED = 20;
         const rating = parseFloat(rating_summary / ONE_FIFTH_OF_A_HUNDRED).toFixed(2);

--- a/src/app/component/ProductActions/ProductActions.style.scss
+++ b/src/app/component/ProductActions/ProductActions.style.scss
@@ -109,8 +109,15 @@
         }
     }
 
-    &-Price {
+    &-Schema {
         order: 21;
+
+        &-Url {
+            display: none;
+        }
+    }
+
+    &-Price {
         font-size: 25px;
         align-items: center;
         justify-content: center;

--- a/src/app/component/ProductCard/ProductCard.component.js
+++ b/src/app/component/ProductCard/ProductCard.component.js
@@ -110,7 +110,6 @@ export default class ProductCard extends PureComponent {
                   style={ { display: 'none' } }
                   alt={ name }
                   src={ thumbnail }
-                  itemProp="image"
                 />
             </>
         );
@@ -127,12 +126,7 @@ export default class ProductCard extends PureComponent {
             <div
               block="ProductCard"
               elem="Reviews"
-              itemProp="aggregateRating"
-              itemScope
-              itemType="https://schema.org/AggregateRating"
             >
-                <meta itemProp="ratingValue" content={ rating || 0 } />
-                <meta itemProp="ratingCount" content={ review_count || 0 } />
                 <ProductReviewRating summary={ rating_summary || 0 } />
             </div>
         );
@@ -150,7 +144,6 @@ export default class ProductCard extends PureComponent {
               block="ProductCard"
               elem="Brand"
               mods={ { isLoaded: !!brand } }
-              itemProp="brand"
             >
                 <ProductAttributeValue
                   attribute={ brand }
@@ -168,7 +161,6 @@ export default class ProductCard extends PureComponent {
               block="ProductCard"
               elem="Name"
               mods={ { isLoaded: !!name } }
-              itemProp="name"
             >
                 <TextPlaceholder content={ name } length="medium" />
             </p>
@@ -205,12 +197,9 @@ export default class ProductCard extends PureComponent {
         return (
             <li
               block="ProductCard"
-              itemScope
-              itemType={ sku && 'https://schema.org/Product' }
               mix={ mix }
             >
                 <Loader isLoading={ isLoading } />
-                <meta itemProp="sku" content={ sku } />
                 { this.renderCardWrapper((
                     <>
                         <figure block="ProductCard" elem="Figure">

--- a/src/app/component/ProductPrice/ProductPrice.component.js
+++ b/src/app/component/ProductPrice/ProductPrice.component.js
@@ -24,12 +24,9 @@ import './ProductPrice.style';
 export default class ProductPrice extends PureComponent {
     static propTypes = {
         isSchemaRequired: PropTypes.bool.isRequired,
-        minimalPriceValue: PropTypes.number,
-        regularPriceValue: PropTypes.number,
         roundedRegularPrice: PropTypes.string,
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
-        finalPrice: PropTypes.number,
         formatedCurrency: PropTypes.string,
         currency: PropTypes.string,
         price: PriceType,
@@ -37,12 +34,9 @@ export default class ProductPrice extends PureComponent {
     };
 
     static defaultProps = {
-        minimalPriceValue: 0,
-        regularPriceValue: 0,
         roundedRegularPrice: '0',
         priceCurrency: 'USD',
         discountPercentage: 0,
-        finalPrice: 0,
         formatedCurrency: '0',
         currency: '$',
         mix: {},

--- a/src/app/component/ProductPrice/ProductPrice.component.js
+++ b/src/app/component/ProductPrice/ProductPrice.component.js
@@ -110,7 +110,9 @@ export default class ProductPrice extends PureComponent {
         const { isSchemaRequired, priceCurrency } = this.props;
 
         if (isSchemaRequired) {
-            return <meta itemProp="priceCurrency" content={ priceCurrency } />;
+            return (
+                <meta itemProp="priceCurrency" content={ priceCurrency } />
+            );
         }
 
         return null;
@@ -119,7 +121,6 @@ export default class ProductPrice extends PureComponent {
     render() {
         const {
             price: { minimalPrice, regularPrice },
-            isSchemaRequired,
             formatedCurrency,
             currency,
             mix
@@ -129,19 +130,11 @@ export default class ProductPrice extends PureComponent {
             return this.renderPlaceholder();
         }
 
-        const schemaObject = isSchemaRequired
-            ? {
-                itemType: 'https://schema.org/AggregateOffer',
-                itemProp: 'offers',
-                itemScope: true
-            } : {};
-
         return (
             <p
               block="ProductPrice"
               mix={ mix }
               aria-label={ `Product price: ${ formatedCurrency }${ currency }` }
-              { ...schemaObject }
             >
                 { this.renderCurrentPrice() }
                 { this.renderOldPrice() }

--- a/src/app/component/ProductPrice/ProductPrice.component.js
+++ b/src/app/component/ProductPrice/ProductPrice.component.js
@@ -9,14 +9,9 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import TextPlaceholder from 'Component/TextPlaceholder';
-import {
-    formatCurrency,
-    calculateDiscountPercentage,
-    calculateFinalPrice,
-    roundPrice
-} from 'Util/Price';
 import { PriceType } from 'Type/ProductList';
 import { MixType } from 'Type/Common';
 
@@ -28,70 +23,129 @@ import './ProductPrice.style';
  */
 export default class ProductPrice extends PureComponent {
     static propTypes = {
+        isSchemaRequired: PropTypes.bool.isRequired,
+        minimalPriceValue: PropTypes.number,
+        regularPriceValue: PropTypes.number,
+        roundedRegularPrice: PropTypes.string,
+        priceCurrency: PropTypes.string,
+        discountPercentage: PropTypes.number,
+        finalPrice: PropTypes.number,
+        formatedCurrency: PropTypes.string,
+        currency: PropTypes.string,
         price: PriceType,
         mix: MixType
     };
 
     static defaultProps = {
+        minimalPriceValue: 0,
+        regularPriceValue: 0,
+        roundedRegularPrice: '0',
+        priceCurrency: 'USD',
+        discountPercentage: 0,
+        finalPrice: 0,
+        formatedCurrency: '0',
+        currency: '$',
         mix: {},
         price: {}
     };
 
+    renderPlaceholder() {
+        const { mix } = this.props;
+
+        return (
+            <p block="ProductPrice" aria-label="Product Price" mix={ mix }>
+                <TextPlaceholder mix={ { block: 'ProductPrice', elem: 'Placeholder' } } length="custom" />
+            </p>
+        );
+    }
+
+    renderCurrentPrice() {
+        const {
+            discountPercentage,
+            isSchemaRequired,
+            formatedCurrency,
+            currency
+        } = this.props;
+
+        const schema = isSchemaRequired ? { itemProp: 'lowPrice' } : {};
+
+        // Use <ins></ins> <del></del> to represent new price and the old (deleted) one
+        const PriceSemanticElementName = discountPercentage > 0 ? 'ins' : 'span';
+
+        return (
+            <PriceSemanticElementName>
+                <data
+                  value={ formatedCurrency }
+                >
+                    <span>{ currency }</span>
+                    <span { ...schema }>{ formatedCurrency }</span>
+                </data>
+            </PriceSemanticElementName>
+        );
+    }
+
+    renderOldPrice() {
+        const {
+            roundedRegularPrice,
+            discountPercentage,
+            isSchemaRequired
+        } = this.props;
+
+        const schema = isSchemaRequired ? { itemProp: 'highPrice' } : {};
+
+        return (
+            <del
+              block="ProductPrice"
+              elem="HighPrice"
+              mods={ { isVisible: discountPercentage > 0 } }
+              aria-label={ __('Old product price') }
+              { ...schema }
+            >
+                { roundedRegularPrice }
+            </del>
+        );
+    }
+
+    renderSchema() {
+        const { isSchemaRequired, priceCurrency } = this.props;
+
+        if (isSchemaRequired) {
+            return <meta itemProp="priceCurrency" content={ priceCurrency } />;
+        }
+
+        return null;
+    }
+
     render() {
         const {
             price: { minimalPrice, regularPrice },
+            isSchemaRequired,
+            formatedCurrency,
+            currency,
             mix
         } = this.props;
 
         if (!minimalPrice || !regularPrice) {
-            return (
-                <p block="ProductPrice" aria-label="Product Price" mix={ mix }>
-                    <TextPlaceholder mix={ { block: 'ProductPrice', elem: 'Placeholder' } } length="custom" />
-                </p>
-            );
+            return this.renderPlaceholder();
         }
 
-        const minimalPriceValue = minimalPrice.amount.value;
-        const regularPriceValue = regularPrice.amount.value;
-        const roundedRegularPrice = roundPrice(regularPriceValue);
-        const priceCurrency = regularPrice.amount.currency;
-        const discountPercentage = calculateDiscountPercentage(minimalPriceValue, regularPriceValue);
-        const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
-        const formatedCurrency = roundPrice(finalPrice);
-        const currency = formatCurrency(priceCurrency);
-
-        // Use <ins></ins> <del></del> to represent new price and the old (deleted) one
-        const PriceSemanticElementName = discountPercentage > 0 ? 'ins' : 'span';
+        const schemaObject = isSchemaRequired
+            ? {
+                itemType: 'https://schema.org/AggregateOffer',
+                itemProp: 'offers',
+                itemScope: true
+            } : {};
 
         return (
             <p
               block="ProductPrice"
               mix={ mix }
               aria-label={ `Product price: ${ formatedCurrency }${ currency }` }
-              itemProp="offers"
-              itemScope
-              itemType="https://schema.org/AggregateOffer"
+              { ...schemaObject }
             >
-                <PriceSemanticElementName>
-                    <data
-                      value={ formatedCurrency }
-                    >
-                        <span>{ currency }</span>
-                        <span itemProp="lowPrice">{ formatedCurrency }</span>
-                    </data>
-                </PriceSemanticElementName>
-
-                <del
-                  block="ProductPrice"
-                  elem="HighPrice"
-                  mods={ { isVisible: discountPercentage > 0 } }
-                  aria-label={ __('Old product price') }
-                  itemProp="highPrice"
-                >
-                    { roundedRegularPrice }
-                </del>
-
-                <meta itemProp="priceCurrency" content={ priceCurrency } />
+                { this.renderCurrentPrice() }
+                { this.renderOldPrice() }
+                { this.renderSchema() }
             </p>
         );
     }

--- a/src/app/component/ProductPrice/ProductPrice.container.js
+++ b/src/app/component/ProductPrice/ProductPrice.container.js
@@ -54,12 +54,9 @@ class ProductPriceContainer extends PureComponent {
         const currency = formatCurrency(priceCurrency);
 
         return {
-            minimalPriceValue,
-            regularPriceValue,
             roundedRegularPrice,
             priceCurrency,
             discountPercentage,
-            finalPrice,
             formatedCurrency,
             currency
         };

--- a/src/app/component/ProductPrice/ProductPrice.container.js
+++ b/src/app/component/ProductPrice/ProductPrice.container.js
@@ -9,9 +9,16 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { PriceType } from 'Type/ProductList';
 import { MixType } from 'Type/Common';
+import {
+    formatCurrency,
+    calculateDiscountPercentage,
+    calculateFinalPrice,
+    roundPrice
+} from 'Util/Price';
 import ProductPrice from './ProductPrice.component';
 /**
  * Product price
@@ -19,19 +26,50 @@ import ProductPrice from './ProductPrice.component';
  */
 class ProductPriceContainer extends PureComponent {
     static propTypes = {
+        isSchemaRequired: PropTypes.bool,
         price: PriceType,
         mix: MixType
     };
 
     static defaultProps = {
+        isSchemaRequired: false,
         mix: {},
         price: {}
+    };
+
+    containerProps = () => {
+        const { price: { minimalPrice, regularPrice } } = this.props;
+
+        if (!minimalPrice || !regularPrice) {
+            return {};
+        }
+
+        const minimalPriceValue = minimalPrice.amount.value;
+        const regularPriceValue = regularPrice.amount.value;
+        const roundedRegularPrice = roundPrice(regularPriceValue);
+        const priceCurrency = regularPrice.amount.currency;
+        const discountPercentage = calculateDiscountPercentage(minimalPriceValue, regularPriceValue);
+        const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
+        const formatedCurrency = roundPrice(finalPrice);
+        const currency = formatCurrency(priceCurrency);
+
+        return {
+            minimalPriceValue,
+            regularPriceValue,
+            roundedRegularPrice,
+            priceCurrency,
+            discountPercentage,
+            finalPrice,
+            formatedCurrency,
+            currency
+        };
     };
 
     render() {
         return (
             <ProductPrice
               { ...this.props }
+              { ...this.containerProps() }
             />
         );
     }

--- a/src/app/component/ProductReviewList/ProductReviewList.component.js
+++ b/src/app/component/ProductReviewList/ProductReviewList.component.js
@@ -43,8 +43,14 @@ export default class ProductReviewList extends PureComponent {
               key={ vote_id }
               block="ProductReviewList"
               elem="RatingSummaryItem"
+              itemType="http://schema.org/Rating"
+              itemScope
+              itemProp="reviewRating"
             >
-                <p>{ rating_code }</p>
+                <p itemProp="name">{ rating_code }</p>
+                <meta itemProp="ratingValue" content={ percent } />
+                <meta itemProp="worstRating" content={ 0 } />
+                <meta itemProp="bestRating" content={ 100 } />
                 <ProductReviewRating
                   summary={ percent }
                   code={ rating_code }
@@ -59,7 +65,8 @@ export default class ProductReviewList extends PureComponent {
         return (
             <p block="ProductReviewList" elem="ReviewAuthor">
                 { __('Written by ') }
-                <strong>{ nickname }</strong>
+                <strong itemProp="author">{ nickname }</strong>
+                <meta itemProp="datePublished" content={ this.getFormattedDate(created_at) } />
                 { __(', written at %s', this.getFormattedDate(created_at)) }
             </p>
         );
@@ -78,15 +85,18 @@ export default class ProductReviewList extends PureComponent {
               key={ review_id }
               block="ProductReviewList"
               elem="Item"
+              itemType="http://schema.org/Review"
+              itemProp="review"
+              itemScope
             >
-                <h4 block="ProductReviewList" elem="ReviewTitle">
+                <h4 block="ProductReviewList" elem="ReviewTitle" itemProp="name">
                     { title }
                 </h4>
                 <div block="ProductReviewList" elem="RatingSummary">
                     { rating_votes.map(this.renderReviewListItemRating) }
                 </div>
                 <div block="ProductReviewList" elem="ReviewContent">
-                    <p block="ProductReviewList" elem="ReviewDetails">
+                    <p block="ProductReviewList" elem="ReviewDetails" itemProp="reviewBody">
                         { detail }
                     </p>
                     { this.renderAuthor(reviewItem) }

--- a/src/app/component/ProductReviews/ProductReviews.component.js
+++ b/src/app/component/ProductReviews/ProductReviews.component.js
@@ -71,6 +71,17 @@ class ProductReviews extends PureComponent {
         );
     }
 
+    renderRatingSchema(percent, reviewCount) {
+        return (
+            <>
+                <meta itemProp="ratingValue" content={ percent } />
+                <meta itemProp="worstRating" content={ 0 } />
+                <meta itemProp="bestRating" content={ 100 } />
+                <meta itemProp="reviewCount" content={ reviewCount } />
+            </>
+        );
+    }
+
     renderRatingData() {
         const {
             product: {
@@ -86,10 +97,11 @@ class ProductReviews extends PureComponent {
 
         const percent = parseFloat(STARS_COUNT * (rating_summary || 0) / PERCENT).toFixed(2);
 
-        if (!rating_summary) return this.renderNoRating();
+        if (rating_summary !== 0 && !rating_summary) return this.renderNoRating();
 
         return (
             <>
+                { this.renderRatingSchema(percent, review_count) }
                 <ProductReviewRating
                   mix={ { block: 'ProductReviews', elem: 'SummaryRating' } }
                   summary={ rating_summary }
@@ -104,7 +116,13 @@ class ProductReviews extends PureComponent {
 
     renderSummary() {
         return (
-            <div block="ProductReviews" elem="Summary">
+            <div
+              block="ProductReviews"
+              elem="Summary"
+              itemType="http://schema.org/AggregateRating"
+              itemProp="aggregateRating"
+              itemScope
+            >
                 <h3 block="ProductReviews" elem="Title">
                     { __('Customer reviews') }
                 </h3>

--- a/src/app/component/ProductReviews/ProductReviews.component.js
+++ b/src/app/component/ProductReviews/ProductReviews.component.js
@@ -97,7 +97,7 @@ class ProductReviews extends PureComponent {
 
         const percent = parseFloat(STARS_COUNT * (rating_summary || 0) / PERCENT).toFixed(2);
 
-        if (rating_summary !== 0 && !rating_summary) return this.renderNoRating();
+        if (!review_count) return this.renderNoRating();
 
         return (
             <>
@@ -115,13 +115,26 @@ class ProductReviews extends PureComponent {
     }
 
     renderSummary() {
+        const {
+            product: {
+                review_summary: {
+                    review_count
+                } = {}
+            }
+        } = this.props;
+
+        const reviewSchemaObject = review_count
+            ? {
+                itemType: 'http://schema.org/AggregateRating',
+                itemProp: 'aggregateRating',
+                itemScope: true
+            } : {};
+
         return (
             <div
               block="ProductReviews"
               elem="Summary"
-              itemType="http://schema.org/AggregateRating"
-              itemProp="aggregateRating"
-              itemScope
+              { ...reviewSchemaObject }
             >
                 <h3 block="ProductReviews" elem="Title">
                     { __('Customer reviews') }

--- a/src/app/route/ProductPage/ProductPage.component.js
+++ b/src/app/route/ProductPage/ProductPage.component.js
@@ -88,18 +88,18 @@ export default class ProductPage extends PureComponent {
     render() {
         return (
             <>
-                <main block="ProductPage" aria-label="Product page">
-                    <div
-                      itemScope
-                      itemType="http://schema.org/Product"
+                <main
+                  block="ProductPage"
+                  aria-label="Product page"
+                  itemScope
+                  itemType="http://schema.org/Product"
+                >
+                    <ContentWrapper
+                      wrapperMix={ { block: 'ProductPage', elem: 'Wrapper' } }
+                      label={ __('Main product details') }
                     >
-                        <ContentWrapper
-                          wrapperMix={ { block: 'ProductPage', elem: 'Wrapper' } }
-                          label={ __('Main product details') }
-                        >
-                            { this.renderProductPageContent() }
-                        </ContentWrapper>
-                    </div>
+                        { this.renderProductPageContent() }
+                    </ContentWrapper>
                     { this.renderAdditionalSections() }
                 </main>
             </>

--- a/src/app/route/ProductPage/ProductPage.container.js
+++ b/src/app/route/ProductPage/ProductPage.container.js
@@ -144,10 +144,13 @@ export class ProductPageContainer extends PureComponent {
 
     getLink(key, value) {
         const { location: { search, pathname } } = this.props;
-        const query = objectToUri({
-            ...convertQueryStringToKeyValuePairs(search),
-            [key]: value
-        });
+        const obj = {
+            ...convertQueryStringToKeyValuePairs(search)
+        };
+
+        if (key) obj[key] = value;
+
+        const query = objectToUri(obj);
 
         return `${pathname}${query}`;
     }


### PR DESCRIPTION
Based on earlier implemented schema enhancement https://github.com/scandipwa/base-theme/pull/581

* Integrated Schema on PDP
* Integrated missing fields: URL, review, stock availability  
* Convenient integration of schema for extending it further for simple and grouped product types.

Before:
<img width="789" alt="Screenshot 2020-03-19 at 00 10 44" src="https://user-images.githubusercontent.com/53301511/77012164-2077c900-6976-11ea-8570-c2c036098259.png">

After:
* No reviews
<img width="781" alt="Screenshot 2020-03-18 at 23 57 36" src="https://user-images.githubusercontent.com/53301511/77012190-2a99c780-6976-11ea-981c-6a191751f53b.png">

* With reviews (review criterion were simulated, as reviews do not work properly at the moment)
<img width="813" alt="Screenshot 2020-03-18 at 23 36 21" src="https://user-images.githubusercontent.com/53301511/77012200-308fa880-6976-11ea-85c9-1b1b8b10e37c.png">
