### PR TITLE
Resolved issue with prepareDocument variables

### DIFF
--- a/src/app/util/Query/PrepareDocument.js
+++ b/src/app/util/Query/PrepareDocument.js
@@ -22,6 +22,7 @@ const QUERY_TYPE = 'query';
  * @return {String} JSON String, format: `{"query":"{alias: queryName (attr:key) { field1, field2 }}"}`
  */
 const prepareDocument = (queries) => {
+    const args = [];
     const querySelections = [];
     const variableDefinitions = [];
     const variableAssignments = queries.reduce((variableAssignmentMap, querySelection) => {
@@ -30,7 +31,7 @@ const prepareDocument = (queries) => {
             return {};
         }
 
-        querySelection.build();
+        querySelection.build(args);
         querySelections.push(querySelection.toString());
         variableDefinitions.push(...querySelection.variableDefinitions);
 


### PR DESCRIPTION
This PR resolves an issue with multiple, identical arguments being defined for query, if multiple fields with identical argument names have been defined.

i.e query defined as `query { field0(arg: \\), field1(arg: \/) }` would be converted to

```
query($_arg_0: Scalar!, $_arg_0: Scalar!) {
    field0(arg: $_arg_0),
    field1(arg: $_arg_0)
}

arguments {
    $_arg_0: \\
}
```
Instead of
```
query($_arg_0: Scalar!, $_arg_1: Scalar!) {
    field0(arg: $_arg_0),
    field1(arg: $_arg_1)
}

arguments {
    $_arg_0: \\,
    $_arg_1: \/
}
```