### PR TITLE
Redirect to Myacount in Checkout

### DIFF
--- a/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -143,7 +143,7 @@ export class MyAccountOverlayContainer extends PureComponent {
         const { state: oldMyAccountState } = prevState;
         const { state: newMyAccountState } = this.state;
         const { hideActiveOverlay } = this.props;
-        const { location: { pathname } } = history;
+        const { location: { pathname } } = window;
 
         if (oldMyAccountState === newMyAccountState) {
             return;

--- a/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
+++ b/src/app/component/MyAccountOverlay/MyAccountOverlay.container.js
@@ -153,7 +153,7 @@ export class MyAccountOverlayContainer extends PureComponent {
             hideActiveOverlay();
         }
 
-        if (pathname.includes(CHECKOUT_URL) && newMyAccountState === STATE_LOGGED_IN) {
+        if (!pathname.includes(CHECKOUT_URL) && newMyAccountState === STATE_LOGGED_IN) {
             history.push({ pathname: '/my-account/dashboard' });
         }
     }


### PR DESCRIPTION
Incorrect check, updated with correct condition.
The condition should check that current page is not checkout (it was in the previous commit, but  changed to incorrect)