### PR TITLE
[issue #729] Disallowing to enter Search page when there is no input …

### DIFF
--- a/src/app/component/SearchField/SearchField.component.js
+++ b/src/app/component/SearchField/SearchField.component.js
@@ -67,7 +67,7 @@ class SearchField extends PureComponent {
         if (e.key === 'Enter') {
             const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
             const search = searchCriteria.replace(/\s\s+/g, '%20');
-            if (search) {
+            if (searchCriteria.trim()) {
                 history.push(`/search/${ search }`);
                 hideActiveOverlay();
                 onSearchBarChange({ target: { value: '' } });

--- a/src/app/component/SearchField/SearchField.component.js
+++ b/src/app/component/SearchField/SearchField.component.js
@@ -67,12 +67,13 @@ class SearchField extends PureComponent {
         if (e.key === 'Enter') {
             const { searchCriteria, hideActiveOverlay, onSearchBarChange } = this.props;
             const search = searchCriteria.replace(/\s\s+/g, '%20');
-
-            history.push(`/search/${ search }`);
-            hideActiveOverlay();
-            onSearchBarChange({ target: { value: '' } });
-            this.searchBarRef.current.blur();
-            this.closeSearch();
+            if (search) {
+                history.push(`/search/${ search }`);
+                hideActiveOverlay();
+                onSearchBarChange({ target: { value: '' } });
+                this.searchBarRef.current.blur();
+                this.closeSearch();
+            }
         }
     };
 

--- a/src/app/component/SearchOverlay/SearchOverlay.component.js
+++ b/src/app/component/SearchOverlay/SearchOverlay.component.js
@@ -139,7 +139,7 @@ export default class SearchOverlay extends PureComponent {
             <p
               block="SearchOverlay"
               elem="Criteria"
-              mods={ { isVisible: !!searchCriteria } }
+              mods={ { isVisible: !!searchCriteria.trim() } }
             >
                 { __('Results for:') }
                 <strong>{ searchCriteria }</strong>


### PR DESCRIPTION
**issue**: In Search Bar when there is input provided message is given as Start typing to see search results! but when the ENTER character is entered it redirects to Search Page which is 404! if entering the search page without any result redirects to 404.

Condition to stop redirecting to search page when there is no input