### PR TITLE
Added missing namespaces for several components

### DIFF
--- a/src/app/component/ProductCustomizableOption/ProductCustomizableOption.component.js
+++ b/src/app/component/ProductCustomizableOption/ProductCustomizableOption.component.js
@@ -19,6 +19,7 @@ export const DROPDOWN = 'dropdown';
 export const TEXT_FIELD = 'field';
 export const AREA_FIELD = 'area';
 
+/** @namespace Component/ProductCustomizableOption/Component */
 class ProductCustomizableOption extends ExtensiblePureComponent {
     static propTypes = {
         option: PropTypes.object.isRequired,

--- a/src/app/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/src/app/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { formatCurrency } from 'Util/Price';
 import ProductCustomizableOption from './ProductCustomizableOption.component';
 
+/** @namespace Component/ProductCustomizableOption/Container */
 class ProductCustomizableOptionContainer extends ExtensiblePureComponent {
     static propTypes = {
         option: PropTypes.object.isRequired,

--- a/src/app/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
+++ b/src/app/component/ProductCustomizableOptions/ProductCustomizableOptions.component.js
@@ -14,6 +14,7 @@ import ProductCustomizableOption from 'Component/ProductCustomizableOption';
 
 import './ProductCustomizableOptions.style';
 
+/** @namespace Component/ProductCustomizableOptions/Component */
 class ProductCustomizableOptions extends ExtensiblePureComponent {
     static propTypes = {
         isLoading: PropTypes.bool.isRequired,

--- a/src/app/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
+++ b/src/app/component/ProductCustomizableOptions/ProductCustomizableOptions.container.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { OptionsType } from 'Type/ProductList';
 import ProductCustomizableOptions from './ProductCustomizableOptions.component';
 
+/** @namespace Component/ProductCustomizableOptions/Container */
 class ProductCustomizableOptionsContainer extends ExtensiblePureComponent {
     static propTypes = {
         options: OptionsType,

--- a/src/app/component/StoreItems/StoreItems.component.js
+++ b/src/app/component/StoreItems/StoreItems.component.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 
 import './StoreItems.style';
 
+/** @namespace Component/StoreItems/Component */
 class StoreItems extends ExtensiblePureComponent {
     static propTypes = {
         item: PropTypes.object.isRequired,


### PR DESCRIPTION
Added missing namespaces for following components:

- ProductCustomizableOption
- ProductCustomizableOptionContainer
- ProductCustomizableOptions
- ProductCustomizableOptionsContainer
- StoreItems

As long as they're missing, multistore and several product types won't be working due to exception being thrown while trying to proxy these components for plugins.