### PR TITLE
[issue #770] Same shipping address fix

### DIFF
--- a/src/app/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.container.js
@@ -83,16 +83,20 @@ export class CheckoutBillingContainer extends PureComponent {
     constructor(props) {
         super(props);
 
-        const { paymentMethods, totals: { is_virtual } } = props;
+        const { paymentMethods, customer } = props;
         const [method] = paymentMethods;
         const { code: paymentMethod } = method || {};
 
         this.state = {
-            isSameAsShipping: !is_virtual,
+            isSameAsShipping: this.isSameShippingAddress(customer),
             selectedCustomerAddressId: 0,
             prevPaymentMethods: paymentMethods,
             paymentMethod
         };
+    }
+
+    isSameShippingAddress({ default_billing, default_shipping }) {
+        return default_billing === default_shipping;
     }
 
     onAddressSelect(id) {


### PR DESCRIPTION
Fixed checkout “My billing and shipping are the same” checkbox is always checked, even if different ones are selected in the address book.