### PR TITLE
786 migrate to webpack dev server proxy

### DIFF
--- a/src/config/webpack.development.config.js
+++ b/src/config/webpack.development.config.js
@@ -33,6 +33,31 @@ const { parentTheme = '' } = require(path.resolve(projectRoot, 'scandipwa.json')
 const DEVELOPMENT = 'development';
 const CORE = 'core';
 
+const prepareProxy = (env) => {
+    const proxy = env.PROXY_TARGET || require("../../package.json").proxy;
+    if (!proxy) {
+        return undefined;
+    }
+    console.log('proxy is defined');
+    if (typeof proxy !== 'string') {
+        console.log('When specified, "proxy" in package.json must be a string.');
+        console.log('Instead, the type of "proxy" was "' + typeof proxy + '".');
+        console.log('Either remove "proxy" from package.json, or make it a string.');
+        process.exit(1);
+    }
+    if (!/^http(s)?:\/\//.test(proxy)) {
+        console.log('When "proxy" is specified in package.json it must start with either http:// or https://');
+        process.exit(1);
+    }
+    return [{
+        context: ['/graphql', '/static', '/media', '/admin', '/pub'],
+        target: proxy,
+        ws: true,
+        changeOrigin: true,
+        logLevel: env.PROXY_LOGLEVEL || 'silent'
+    }];
+}
+
 const config = (env, argv) => {
     const magentoRoot = env.BUILD_MODE === DEVELOPMENT
         ? path.resolve(projectRoot, '..', '..', '..', '..', '..')
@@ -202,7 +227,8 @@ const config = (env, argv) => {
             public: 'scandipwa.local',
             allowedHosts: [
                 '.local'
-            ]
+            ],
+            proxy: prepareProxy(env)
         },
 
         watchOptions: {

--- a/src/config/webpack.development.config.js
+++ b/src/config/webpack.development.config.js
@@ -217,14 +217,14 @@ const config = (env, argv) => {
                 index: '/',
                 disableDotRule: true
             },
-            port: 3003,
+            port: env.PORT || 3003,
             https: false,
             overlay: true,
             compress: true,
             inline: true,
             hot: true,
             host: '0.0.0.0',
-            public: 'scandipwa.local',
+            public: env.HOST || 'scandipwa.local',
             allowedHosts: [
                 '.local'
             ],


### PR DESCRIPTION
Fix #786 

It allows proxy definition in package.json:
```
{
    ...
    "proxy": "https://demo.scandipwa.com"
}
```

or as a environment variable:
```sh
--env.PROXY_TARGET=https://demo.scandipwa.com
```

Also, it provides 3 environments variables:
```
# add debug for proxy:
env.PROXY_LOGLEVEL=debug

# override default scandipwa port (3003)
env.PORT

# override default scandipwa hostname (scandipwa.local)
env.HOST
```

