### PR TITLE
Issue #722 mobile filters fix

### DIFF
--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.component.js
@@ -30,6 +30,7 @@ export default class CategoryFilterOverlay extends PureComponent {
         isProductsLoading: PropTypes.bool.isRequired,
         onSeeResultsClick: PropTypes.func.isRequired,
         onVisible: PropTypes.func.isRequired,
+        onHide: PropTypes.func.isRequired,
         customFiltersValues: PropTypes.objectOf(PropTypes.array).isRequired,
         toggleCustomFilter: PropTypes.func.isRequired,
         getFilterUrl: PropTypes.func.isRequired,
@@ -169,6 +170,7 @@ export default class CategoryFilterOverlay extends PureComponent {
     render() {
         const {
             onVisible,
+            onHide,
             totalPages,
             isProductsLoading,
             isContentFiltered
@@ -183,6 +185,7 @@ export default class CategoryFilterOverlay extends PureComponent {
         return (
             <Overlay
               onVisible={ onVisible }
+              onHide={ onHide }
               mix={ { block: 'CategoryFilterOverlay' } }
               id={ CATEGORY_FILTER_OVERLAY_ID }
               isRenderInPortal={ false }

--- a/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
+++ b/src/app/component/CategoryFilterOverlay/CategoryFilterOverlay.container.js
@@ -55,7 +55,8 @@ export class CategoryFilterOverlayContainer extends PureComponent {
         onSeeResultsClick: this.onSeeResultsClick.bind(this),
         toggleCustomFilter: this.toggleCustomFilter.bind(this),
         getFilterUrl: this.getFilterUrl.bind(this),
-        onVisible: this.onVisible.bind(this)
+        onVisible: this.onVisible.bind(this),
+        onHide: this.onHide.bind(this)
     };
 
     onSeeResultsClick() {
@@ -72,21 +73,54 @@ export class CategoryFilterOverlayContainer extends PureComponent {
 
     onVisible() {
         const {
+            hideActiveOverlay,
             changeHeaderState,
             changeNavigationState,
-            goToPreviousNavigationState
+            goToPreviousNavigationState,
+            location: { pathname, search }
         } = this.props;
 
         changeHeaderState({
             name: FILTER,
             title: __('Filters'),
-            onCloseClick: () => goToPreviousNavigationState()
+            onCloseClick: () => {
+                hideActiveOverlay();
+                goToPreviousNavigationState();
+            }
         });
 
         changeNavigationState({
             name: FILTER,
             isHidden: true
         });
+        window.addEventListener('popstate', this.historyBackHook);
+
+        history.pushState(
+            { overlayOpen: true },
+            '',
+            pathname + search
+        );
+    }
+
+    historyBackHook = () => {
+        const {
+            goToPreviousNavigationState,
+            customFiltersValues,
+            hideActiveOverlay,
+            goToPreviousHeaderState
+        } = this.props;
+
+        goToPreviousNavigationState();
+
+        // close filter only if no applied filters left
+        if (Object.keys(customFiltersValues).length === 0) {
+            hideActiveOverlay();
+            goToPreviousHeaderState();
+        }
+    };
+
+    onHide() {
+        window.removeEventListener('popstate', this.historyBackHook);
     }
 
     /**

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -12,14 +12,25 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { HistoryType } from 'Type/Common';
 import { FilterInputType, PagesType } from 'Type/ProductList';
 import { LocationType } from 'Type/Router';
+import {
+    ProductListInfoDispatcher
+} from 'Store/ProductListInfo';
 import isMobile from 'Util/Mobile';
 import { getQueryParam, setQueryParams } from 'Util/Url';
 
 import ProductList from './ProductList.component';
+
+export const UPDATE_PAGE_FREQUENCY = 0; // (ms)
+
+export const mapDispatchToProps = (dispatch) => ({
+    requestProductListInfo: (options) => ProductListInfoDispatcher.handleData(dispatch, options)
+});
 
 export class ProductListContainer extends PureComponent {
     containerFunctions = {
@@ -37,6 +48,7 @@ export class ProductListContainer extends PureComponent {
         isLoading: PropTypes.bool.isRequired,
         totalItems: PropTypes.number.isRequired,
         requestProductList: PropTypes.func.isRequired,
+        requestProductListInfo: PropTypes.func.isRequired,
         selectedFilters: PropTypes.objectOf(PropTypes.shape),
         isInfiniteLoaderEnabled: PropTypes.bool,
         isPaginationEnabled: PropTypes.bool,
@@ -66,7 +78,7 @@ export class ProductListContainer extends PureComponent {
     };
 
     componentDidMount() {
-        const { pages, getIsNewCategory } = this.props;
+        const { pages, getIsNewCategory, filter } = this.props;
         const { pagesCount } = this.state;
         const pagesLength = Object.keys(pages).length;
 
@@ -75,7 +87,7 @@ export class ProductListContainer extends PureComponent {
         }
 
         // Is true when category is changed. This check prevents making new requests when navigating back to PLP from PDP
-        if (getIsNewCategory()) {
+        if (getIsNewCategory() || (!getIsNewCategory() && Object.keys(filter).length > 0)) {
             this.requestPage(this._getPageFromUrl());
         }
     }
@@ -108,6 +120,7 @@ export class ProductListContainer extends PureComponent {
             filter,
             pageSize,
             requestProductList,
+            requestProductListInfo,
             noAttributes,
             noVariants,
             isWidget
@@ -132,8 +145,16 @@ export class ProductListContainer extends PureComponent {
                 currentPage
             }
         };
+        const infoOptions = {
+            args: {
+                filter,
+                search,
+                sort
+            }
+        };
 
         requestProductList(options);
+        requestProductListInfo(infoOptions);
     };
 
     containerProps = () => ({
@@ -222,4 +243,4 @@ export class ProductListContainer extends PureComponent {
     }
 }
 
-export default withRouter(ProductListContainer);
+export default withRouter(connect(null, mapDispatchToProps)(ProductListContainer));

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -18,9 +18,7 @@ import { connect } from 'react-redux';
 import { HistoryType } from 'Type/Common';
 import { FilterInputType, PagesType } from 'Type/ProductList';
 import { LocationType } from 'Type/Router';
-import {
-    ProductListInfoDispatcher
-} from 'Store/ProductListInfo/ProductListInfo.dispatcher';
+import ProductListInfoDispatcher from 'Store/ProductListInfo/ProductListInfo.dispatcher';
 import isMobile from 'Util/Mobile';
 import { getQueryParam, setQueryParams } from 'Util/Url';
 

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -20,7 +20,7 @@ import { FilterInputType, PagesType } from 'Type/ProductList';
 import { LocationType } from 'Type/Router';
 import {
     ProductListInfoDispatcher
-} from 'Store/ProductListInfo';
+} from 'Store/ProductListInfo/ProductListInfo.dispatcher';
 import isMobile from 'Util/Mobile';
 import { getQueryParam, setQueryParams } from 'Util/Url';
 

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -11,13 +11,13 @@
 
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
+import ProductListInfoDispatcher from 'Store/ProductListInfo/ProductListInfo.dispatcher';
 import { HistoryType } from 'Type/Common';
 import { FilterInputType, PagesType } from 'Type/ProductList';
 import { LocationType } from 'Type/Router';
-import ProductListInfoDispatcher from 'Store/ProductListInfo/ProductListInfo.dispatcher';
 import isMobile from 'Util/Mobile';
 import { getQueryParam, setQueryParams } from 'Util/Url';
 

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -12,7 +12,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { HistoryType } from 'Type/Common';


### PR DESCRIPTION
Expected behavior with these changes:

- After applying Filter in PLP, if we go back to the homepage and come to the same category, the filter should reset.
- After opening filter, click on any filter > click on delete icon and then if you come back on the category page and close the filter section, the header should be updated.
- After the click of back button on applying more than one filter, page goes to the previous state. If only 1 filter was applied, filters will be cleared and overlay closed.