### PR TITLE
disable export-level-one rule for webpack config and plugins

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,8 +31,7 @@
       {
           "files": ["*.config.js"],
           "rules": {
-              "@scandipwa/scandipwa-guidelines/create-config-files": "off",
-              "@scandipwa/scandipwa-guidelines/export-level-one": "off"
+              "@scandipwa/scandipwa-guidelines/create-config-files": "off"
           }
       }
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,8 @@
       {
           "files": ["*.config.js"],
           "rules": {
-              "@scandipwa/scandipwa-guidelines/create-config-files": "off"
+              "@scandipwa/scandipwa-guidelines/create-config-files": "off",
+              "@scandipwa/scandipwa-guidelines/export-level-one": "off"
           }
       }
   ],

--- a/src/config/FallbackPlugin/index.js
+++ b/src/config/FallbackPlugin/index.js
@@ -14,6 +14,8 @@
 // 2. The file is checked in vendor (later referenced as `core`) folder
 // 3. The file is checked in node_modules of app/design (later referenced as `node`) folder
 
+/* eslint-disable @scandipwa/scandipwa-guidelines/export-level-one */
+
 const path = require('path');
 const fs = require('fs');
 

--- a/src/config/I18nPlugin/index.js
+++ b/src/config/I18nPlugin/index.js
@@ -11,6 +11,7 @@
 
 /* eslint-disable no-unused-vars */
 /* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable @scandipwa/scandipwa-guidelines/export-level-one */
 
 const ConstDependency = require('webpack/lib/dependencies/ConstDependency');
 const NullFactory = require('webpack/lib/NullFactory');

--- a/src/config/TranslationFunction/index.js
+++ b/src/config/TranslationFunction/index.js
@@ -9,6 +9,8 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+/* eslint-disable @scandipwa/scandipwa-guidelines/export-level-one */
+
 const mockTranslations = (format, ...args) => {
     // eslint-disable-next-line fp/no-let
     let i = 0;


### PR DESCRIPTION
Since scandipwa guidelines were written for react mainly, it becomes annoying when they warn for level one export in webpack configs and modules.