### PR TITLE
Imrpove vscode/settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
     "cSpell.words": [
         "Stateful",
         "Unmount"
-    ]
+    ],
+    "search.exclude": {
+        "**/Magento_Theme": true
+    }
 }


### PR DESCRIPTION
Magento_Theme is a generated folder and sometimes search results can become messy because they'll include results from this folder.
This option should fix that and that options can be disabled in vscode search settings, so should be no problem here.