### PR TITLE
enables format-on-save with eslint rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
     ],
     "search.exclude": {
         "**/Magento_Theme": true
-    }
+    },
+    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+    "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,10 @@
 {
-    "cSpell.words": [
-        "Stateful",
-        "Unmount"
-    ],
+    "cSpell.words": ["Stateful", "Unmount"],
     "search.exclude": {
         "**/Magento_Theme": true
     },
-    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "[javascript]": {
+        "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18394,6 +18394,12 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "pm2": "^3.5.1",
     "postcss-cli": "^6.1.0",
     "postcss-loader": "^3.0.0",
+    "prettier": "^2.1.2",
     "redux-devtools": "^3.4.2",
     "sass-loader": "^9.0.3",
     "sass-resources-loader": "^2.1.0",


### PR DESCRIPTION
To use this feature you need to install [Prettier-Eslint](https://marketplace.visualstudio.com/items?itemName=rvest.vs-code-prettier-eslint) extension.

After that js code will be formatted on-save.