### PR TITLE
add Magento_Theme to jsconfig excludes

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,6 +19,7 @@
     }
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "Magento_Theme"
   ]
 }


### PR DESCRIPTION
Magento_Theme folder is a generated folder and because of its size VSCode can throw this warning:
![Screenshot_20200921_140631](https://user-images.githubusercontent.com/18352350/93759942-cea94780-fc13-11ea-89a3-4b7137379384.png)

Magento_Theme folder should be excluded like node_modules folder.