### PR TITLE
[Issue #927] add canonical tags on pdp plp cms page and homepage

### DIFF
--- a/src/app/route/CmsPage/CmsPage.container.js
+++ b/src/app/route/CmsPage/CmsPage.container.js
@@ -159,7 +159,10 @@ export class CmsPageContainer extends DataContainer {
         debounce(this.setOfflineNoticeSize, LOADING_TIME)();
 
         updateBreadcrumbs(page);
-        updateMeta({ title: meta_title || title });
+        updateMeta({
+            title: meta_title || title,
+            canonical_url: window.location.href
+        });
 
         if (
             pathname !== appendWithStoreCode('/')

--- a/src/app/store/Meta/Meta.dispatcher.js
+++ b/src/app/store/Meta/Meta.dispatcher.js
@@ -57,7 +57,7 @@ export class MetaDispatcher {
             description: meta_description,
             keywords: meta_keyword,
             title: meta_title || name,
-            canonical_url
+            canonical_url: `${window.location.origin}/${canonical_url}`
         };
     }
 
@@ -77,7 +77,7 @@ export class MetaDispatcher {
             description: meta_description || description,
             title: meta_title || name,
             keywords: meta_keyword,
-            canonical_url
+            canonical_url: `${window.location.origin}/${canonical_url}`
         };
     }
 }

--- a/src/app/store/Meta/Meta.dispatcher.js
+++ b/src/app/store/Meta/Meta.dispatcher.js
@@ -9,6 +9,7 @@
  * @link https://github.com/scandipwa/base-theme
  */
 import { updateMeta } from 'Store/Meta/Meta.action';
+import { appendWithStoreCode } from 'Util/Url';
 
 /**
  * Meta Dispatcher
@@ -53,13 +54,11 @@ export class MetaDispatcher {
             meta_description
         } = product;
 
-        const storeCode = window.location.pathname.split('/').filter((el) => el !== canonical_url).pop();
-
         return {
             description: meta_description,
             keywords: meta_keyword,
             title: meta_title || name,
-            canonical_url: `${window.location.origin}/${storeCode ? `${storeCode}/` : ''}${canonical_url}`
+            canonical_url: `${window.location.origin}/${appendWithStoreCode(canonical_url)}`
         };
     }
 
@@ -75,13 +74,11 @@ export class MetaDispatcher {
             meta_title, meta_keyword, meta_description
         } = category;
 
-        const storeCode = window.location.pathname.split('/').filter((el) => el !== canonical_url).pop();
-
         return {
             description: meta_description || description,
             title: meta_title || name,
             keywords: meta_keyword,
-            canonical_url: `${window.location.origin}/${storeCode ? `${storeCode}/` : ''}${canonical_url}`
+            canonical_url: `${window.location.origin}/${appendWithStoreCode(canonical_url)}`
         };
     }
 }

--- a/src/app/store/Meta/Meta.dispatcher.js
+++ b/src/app/store/Meta/Meta.dispatcher.js
@@ -53,11 +53,13 @@ export class MetaDispatcher {
             meta_description
         } = product;
 
+        const storeCode = window.location.pathname.split('/').filter((el) => el !== canonical_url).pop();
+
         return {
             description: meta_description,
             keywords: meta_keyword,
             title: meta_title || name,
-            canonical_url: `${window.location.origin}/${canonical_url}`
+            canonical_url: `${window.location.origin}/${storeCode ? `${storeCode}/` : ''}${canonical_url}`
         };
     }
 
@@ -73,11 +75,13 @@ export class MetaDispatcher {
             meta_title, meta_keyword, meta_description
         } = category;
 
+        const storeCode = window.location.pathname.split('/').filter((el) => el !== canonical_url).pop();
+
         return {
             description: meta_description || description,
             title: meta_title || name,
             keywords: meta_keyword,
-            canonical_url: `${window.location.origin}/${canonical_url}`
+            canonical_url: `${window.location.origin}/${storeCode ? `${storeCode}/` : ''}${canonical_url}`
         };
     }
 }

--- a/src/app/store/Meta/Meta.dispatcher.js
+++ b/src/app/store/Meta/Meta.dispatcher.js
@@ -58,7 +58,7 @@ export class MetaDispatcher {
             description: meta_description,
             keywords: meta_keyword,
             title: meta_title || name,
-            canonical_url: `${window.location.origin}/${appendWithStoreCode(canonical_url)}`
+            canonical_url: `${window.location.origin}${appendWithStoreCode(canonical_url)}`
         };
     }
 
@@ -78,7 +78,7 @@ export class MetaDispatcher {
             description: meta_description || description,
             title: meta_title || name,
             keywords: meta_keyword,
-            canonical_url: `${window.location.origin}/${appendWithStoreCode(canonical_url)}`
+            canonical_url: `${window.location.origin}${appendWithStoreCode(canonical_url)}`
         };
     }
 }


### PR DESCRIPTION
Canonical tags on PDP and PLP must be enabled in Magento admin.
_Store > Configuration > Catalog > Catalog > Search Engine Optimization_ and set **Use Canonical Link Meta Tag For Categories** and **Use Canonical Link Meta Tag For Products** to **Yes**.
![Screenshot_20200923_122902](https://user-images.githubusercontent.com/18352350/93994273-6041c200-fd98-11ea-8e42-1b0f48db20eb.png)
