### PR TITLE
Fix header padding for all pages

### DIFF
--- a/src/app/component/Breadcrumbs/Breadcrumbs.style.scss
+++ b/src/app/component/Breadcrumbs/Breadcrumbs.style.scss
@@ -18,7 +18,6 @@
 
 .Breadcrumbs {
     background-color: var(--breadcrumbs-background);
-    margin-top: var(--header-total-height);
 
     $crumb-padding: 20px;
     $arrow-size: 4px;

--- a/src/app/component/Header/Header.component.js
+++ b/src/app/component/Header/Header.component.js
@@ -614,7 +614,7 @@ export class Header extends NavigationAbstract {
         } = this.props;
 
         return (
-            <>
+            <section block="Header" elem="Wrapper">
                 <header block="Header" mods={ { name, isHiddenOnMobile, isCheckout } }>
                     { this.renderTopMenu() }
                     <nav block="Header" elem="Nav">
@@ -623,7 +623,7 @@ export class Header extends NavigationAbstract {
                     { this.renderMenu() }
                 </header>
                 <OfflineNotice />
-            </>
+            </section>
         );
     }
 }

--- a/src/app/component/Header/Header.style.scss
+++ b/src/app/component/Header/Header.style.scss
@@ -75,6 +75,12 @@
         }
     }
 
+    &-Wrapper {
+        @include desktop {
+            margin-bottom: var(--header-total-height);
+        }
+    }
+
     &_isHiddenOnMobile {
         @include before-desktop {
             pointer-events: none;


### PR DESCRIPTION
When the breadcrumb is hidden all pages were going under the header, instead of fixing the margin for
each of them and worring about the breadcrumb being displayed or not, move the margin handing in the header
itself
fixes: #1334