### PR TITLE
[Issue #950] remove tablet view

### DIFF
--- a/src/app/component/CartCoupon/CartCoupon.style.scss
+++ b/src/app/component/CartCoupon/CartCoupon.style.scss
@@ -14,6 +14,10 @@
         width: 100%;
     }
 
+    @include tablet-portrait {
+        width: 100%;
+    }
+
     &-Message {
         display: inline-block;
     }
@@ -27,9 +31,18 @@
             @include before-desktop {
                 width: 100%;
             }
+
+            @include tablet-portrait {
+                width: 100%;
+            }
         }
 
         @include before-desktop {
+            width: 100%;
+            margin-top: 0;
+        }
+
+        @include tablet-portrait {
             width: 100%;
             margin-top: 0;
         }
@@ -39,6 +52,12 @@
         margin-left: 2rem;
 
         @include before-desktop {
+            width: 100%;
+            margin-left: 0;
+            margin-top: 1rem;
+        }
+
+        @include tablet-portrait {
             width: 100%;
             margin-left: 0;
             margin-top: 1rem;

--- a/src/app/component/CartItem/CartItem.style.scss
+++ b/src/app/component/CartItem/CartItem.style.scss
@@ -254,7 +254,7 @@
             top: 1px;
         }
 
-        @include tablet {
+        @include desktop {
             height: auto;
             padding-top: 8px;
             margin-top: 7px;

--- a/src/app/component/CartItem/CartItem.style.scss
+++ b/src/app/component/CartItem/CartItem.style.scss
@@ -254,7 +254,7 @@
             top: 1px;
         }
 
-        @include desktop {
+        @include tablet {
             height: auto;
             padding-top: 8px;
             margin-top: 7px;

--- a/src/app/component/Footer/Footer.component.js
+++ b/src/app/component/Footer/Footer.component.js
@@ -65,11 +65,11 @@ export class Footer extends PureComponent {
     render() {
         const { copyright, isVisibleOnMobile, device } = this.props;
 
-        if (!isVisibleOnMobile && (device.isMobile || device.isTablet)) {
+        if (!isVisibleOnMobile && device.isMobile) {
             return null;
         }
 
-        if (isVisibleOnMobile && (!device.isMobile && device.isTablet)) {
+        if (isVisibleOnMobile && !device.isMobile) {
             return null;
         }
 

--- a/src/app/component/Header/Header.component.js
+++ b/src/app/component/Header/Header.component.js
@@ -372,7 +372,7 @@ export class Header extends NavigationAbstract {
         } = this.props;
 
         // on mobile hide button if not in checkout
-        if ((device.isMobile || device.isTablet) && !isCheckout) {
+        if (device.isMobile && !isCheckout) {
             return null;
         }
 
@@ -472,7 +472,7 @@ export class Header extends NavigationAbstract {
             device
         } = this.props;
 
-        if ((device.isMobile || device.isTablet) || isCheckout) {
+        if (device.isMobile || isCheckout) {
             return null;
         }
 

--- a/src/app/component/Header/Header.style.scss
+++ b/src/app/component/Header/Header.style.scss
@@ -458,10 +458,4 @@
             }
         }
     }
-
-    .Menu-MenuWrapper {
-        @include tablet {
-            display: none;
-        }
-    }
 }

--- a/src/app/component/Header/Header.style.scss
+++ b/src/app/component/Header/Header.style.scss
@@ -350,6 +350,10 @@
             height: 26px;
             margin-left: 2rem;
             padding-right: 1.8rem;
+
+            @include tablet-portrait {
+                margin-left: 0;
+            }
         }
 
         &Title {

--- a/src/app/component/Menu/Menu.component.js
+++ b/src/app/component/Menu/Menu.component.js
@@ -250,7 +250,7 @@ export class Menu extends PureComponent {
 
     renderSubMenuDesktop(itemList) {
         const { device } = this.props;
-        if (device.isMobile || device.isTablet) {
+        if (device.isMobile) {
             return null;
         }
 
@@ -286,7 +286,7 @@ export class Menu extends PureComponent {
         const childrenArray = Object.values(children);
         const itemMods = { type: 'main' };
 
-        if (childrenArray.length && (device.isMobile || device.isTablet)) {
+        if (childrenArray.length && device.isMobile) {
             return (
                 <div
                   // TODO: split into smaller components
@@ -362,7 +362,7 @@ export class Menu extends PureComponent {
 
     renderStoreSwitcher() {
         const { device } = this.props;
-        if (!device.isMobile && !device.isTablet) {
+        if (!device.isMobile) {
             return null;
         }
 

--- a/src/app/component/Menu/Menu.style.scss
+++ b/src/app/component/Menu/Menu.style.scss
@@ -219,6 +219,10 @@
             padding: 0 2rem;
         }
 
+        @include tablet-portrait {
+            padding: 0 .5rem;
+        }
+
         &:first-child {
             margin-top: 0;
 

--- a/src/app/component/MenuItem/MenuItem.component.js
+++ b/src/app/component/MenuItem/MenuItem.component.js
@@ -41,7 +41,7 @@ export class MenuItem extends PureComponent {
         const { isBanner, isLogo, type } = itemMods;
 
         if (!icon
-            || ((!device.isMobile && !device.isTablet) && !isBanner && !isLogo)
+            || (!device.isMobile && !isBanner && !isLogo)
             || (type === 'subcategory')
         ) {
             return null;

--- a/src/app/component/NavigationAbstract/NavigationAbstract.container.js
+++ b/src/app/component/NavigationAbstract/NavigationAbstract.container.js
@@ -60,7 +60,7 @@ export class NavigationAbstractContainer extends PureComponent {
 
     onRouteChanged(history) {
         const { device } = this.props;
-        if (!device.isMobile && !device.isTablet) {
+        if (!device.isMobile) {
             return this.handleDesktopRouteChange(history);
         }
 

--- a/src/app/component/NavigationTabs/NavigationTabs.component.js
+++ b/src/app/component/NavigationTabs/NavigationTabs.component.js
@@ -155,7 +155,7 @@ export class NavigationTabs extends NavigationAbstract {
     render() {
         const { navigationState: { isHidden }, device } = this.props;
 
-        if (!device.isMobile && !device.isTablet) {
+        if (!device.isMobile) {
             return null;
         }
 

--- a/src/app/component/ProductList/ProductList.container.js
+++ b/src/app/component/ProductList/ProductList.container.js
@@ -207,8 +207,8 @@ export class ProductListContainer extends PureComponent {
     _getIsInfiniteLoaderEnabled() { // disable infinite scroll on mobile
         const { isInfiniteLoaderEnabled, device } = this.props;
 
-        // allow scroll and mobile and tablet
-        if (device.isMobile || device.isTablet) {
+        // allow scroll and mobile
+        if (device.isMobile) {
             return isInfiniteLoaderEnabled;
         }
 

--- a/src/app/component/ProductWishlistButton/ProductWishlistButton.style.scss
+++ b/src/app/component/ProductWishlistButton/ProductWishlistButton.style.scss
@@ -10,6 +10,10 @@
     vertical-align: middle;
     display: inline-block;
 
+    @include tablet-portrait {
+        margin-top: 1rem;
+    }
+
     &-Button {
         --button-padding: 0;
         --button-hover-background: transparent;

--- a/src/app/component/Router/Router.container.js
+++ b/src/app/component/Router/Router.container.js
@@ -141,7 +141,6 @@ export class RouterContainer extends PureComponent {
             const { platform, model } = await isMobileClientHints.getDeviceData();
             updateConfigDevice({
                 isMobile: navigator.userAgentData.mobile,
-                isTablet: isMobile.tablet(model),
                 android: isMobile.android(platform),
                 ios: isMobile.iOS(platform),
                 blackberry: isMobile.blackBerry(model),
@@ -151,7 +150,6 @@ export class RouterContainer extends PureComponent {
         } else {
             updateConfigDevice({
                 isMobile: isMobile.any(),
-                isTablet: isMobile.tablet(),
                 android: isMobile.android(),
                 ios: isMobile.iOS(),
                 blackberry: isMobile.blackBerry(),

--- a/src/app/component/SearchField/SearchField.component.js
+++ b/src/app/component/SearchField/SearchField.component.js
@@ -223,7 +223,7 @@ export class SearchField extends PureComponent {
         const { device } = this.props;
         const { showSearch } = this.state;
 
-        if (device.isMobile || device.isTablet) {
+        if (device.isMobile) {
             return null;
         }
 
@@ -249,7 +249,7 @@ export class SearchField extends PureComponent {
             device
         } = this.props;
 
-        if (!device.isMobile && !device.isTablet) {
+        if (!device.isMobile) {
             return null;
         }
 

--- a/src/app/route/CartPage/CartPage.style.scss
+++ b/src/app/route/CartPage/CartPage.style.scss
@@ -29,10 +29,6 @@
             grid-column-gap: 4rem;
         }
 
-        @include tablet {
-            grid-template-columns: 1fr;
-        }
-
         @include before-desktop {
             padding: 0;
         }

--- a/src/app/route/CartPage/CartPage.style.scss
+++ b/src/app/route/CartPage/CartPage.style.scss
@@ -230,12 +230,21 @@
         @include before-desktop {
             display: none;
         }
+        @include tablet-portrait {
+            grid-template-columns: 4fr 1fr;
+        }
 
         span {
             text-align: center;
 
             &:last-of-type {
                 text-align: right;
+            }
+
+            &:nth-child(2) {
+                @include tablet-portrait {
+                    display: none;
+                }
             }
 
             &:first-of-type {
@@ -280,10 +289,33 @@
         }
     }
 
+    .CartItem-Heading {
+        @include tablet-portrait {
+            margin-top: -1.5rem;
+        }
+    }
+
     .CartItem-Actions {
-        @include tablet {
-            flex-direction: column-reverse;
-            justify-content: center;
+        @include tablet-portrait {
+            width: 100%;
+            right: 0;
+            margin: initial;
+            position: relative;
+            display: flex;
+            justify-content: space-between;
+            margin-top: -2rem;
+        }
+
+        .CartItem-Delete {
+            @include tablet-portrait {
+                margin-top: -7px;
+            }
+        }
+
+        > .CartItem-Qty {
+            @include tablet-portrait {
+                margin-left: 8rem;
+            }
         }
     }
 

--- a/src/app/route/CategoryPage/CategoryPage.style.scss
+++ b/src/app/route/CategoryPage/CategoryPage.style.scss
@@ -114,6 +114,10 @@
             grid-template-columns: repeat(2, 1fr);
         }
 
+        @include tablet-portrait {
+            grid-template-rows: 1fr 1fr;
+        }
+
         .hideOnScroll & {
             @include mobile {
                 transform: translateY(-100%);

--- a/src/app/route/MenuPage/MenuPage.container.js
+++ b/src/app/route/MenuPage/MenuPage.container.js
@@ -57,7 +57,7 @@ export class MenuPageContainer extends PureComponent {
     redirectIfNotOnMobile() {
         const { history, device } = this.props;
 
-        if (!device.isMobile && !device.isTablet) {
+        if (!device.isMobile) {
             history.push('/');
         }
     }

--- a/src/app/route/ProductPage/ProductPage.style.scss
+++ b/src/app/route/ProductPage/ProductPage.style.scss
@@ -14,6 +14,11 @@
         padding-top: 1rem;
     }
 
+    @include tablet {
+        padding-top: 0;
+        margin-top: 0;
+    }
+
     @include mobile {
         padding-bottom: 75px;
     }

--- a/src/app/store/Config/Config.reducer.js
+++ b/src/app/store/Config/Config.reducer.js
@@ -38,7 +38,6 @@ export const getInitialState = () => ({
     device: {
         isMobile: true,
         android: true,
-        isTablet: false,
         ios: false,
         blackberry: false,
         opera: false,

--- a/src/app/style/abstract/_media.scss
+++ b/src/app/style/abstract/_media.scss
@@ -10,31 +10,41 @@
  */
 
 @mixin desktop {
-    @media (min-width: 1025px) {
-        @content;
-    }
-}
-
-@mixin before-desktop {
-    @media (max-width: 1024px) {
-        @content;
-    }
-}
-
-@mixin tablet {
-    @media (max-width: 1024px) and (min-width: 768px) {
-        @content;
-    }
-}
-
-@mixin after-mobile {
     @media (min-width: 768px) {
         @content;
     }
 }
 
+@mixin before-desktop {
+    @include mobile {
+        @content;
+    }
+}
+
+@mixin tablet {
+    @media (min-width: 768px)
+        and (max-width: 1024px) {
+        @content;
+    }
+}
+
+@mixin tablet-portrait {
+    @media (min-width: 768px)
+        and (max-width: 1024px)
+        and (orientation: portrait) {
+        @content;
+    }
+}
+
+@mixin after-mobile {
+    @include desktop {
+        @content;
+    }
+}
+
 @mixin mobile {
-    @media (max-width: 767px) {
+    @media only screen
+        and (max-width: 767px) {
         @content;
     }
 }

--- a/src/app/style/abstract/_media.scss
+++ b/src/app/style/abstract/_media.scss
@@ -25,14 +25,14 @@
 
 @mixin tablet {
     @media (min-width: 768px)
-        and (max-width: 1024px) {
+        and (max-width: 1023px) {
         @content;
     }
 }
 
 @mixin tablet-portrait {
     @media (min-width: 768px)
-        and (max-width: 1024px)
+        and (max-width: 1023px)
         and (orientation: portrait) {
         @content;
     }
@@ -40,7 +40,7 @@
 
 @mixin tablet-landscape {
     @media (min-width: 768px)
-        and (max-width: 1024px)
+        and (max-width: 1023px)
         and (orientation: landscape) {
         @content;
     }

--- a/src/app/style/abstract/_media.scss
+++ b/src/app/style/abstract/_media.scss
@@ -15,6 +15,8 @@
     }
 }
 
+// should be removed in future releases
+// kept as legacy support
 @mixin before-desktop {
     @include mobile {
         @content;
@@ -36,6 +38,16 @@
     }
 }
 
+@mixin tablet-landscape {
+    @media (min-width: 768px)
+        and (max-width: 1024px)
+        and (orientation: landscape) {
+        @content;
+    }
+}
+
+// should be removed in future releases
+// kept as legacy support
 @mixin after-mobile {
     @include desktop {
         @content;
@@ -43,8 +55,7 @@
 }
 
 @mixin mobile {
-    @media only screen
-        and (max-width: 767px) {
+    @media (max-width: 767px) {
         @content;
     }
 }

--- a/src/app/style/base/_reset.scss
+++ b/src/app/style/base/_reset.scss
@@ -51,12 +51,6 @@ main {
         margin-top: var(--header-total-height);
         margin-bottom: var(--navigation-tabs-height);
     }
-
-    @include tablet {
-        min-height: calc(100vh - var(--header-height) - var(--navigation-tabs-height) - var(--footer-height));
-        margin-top: var(--header-height);
-        margin-bottom: var(--navigation-tabs-height);
-    }
 }
 
 table {

--- a/src/app/util/Mobile/isMobile.js
+++ b/src/app/util/Mobile/isMobile.js
@@ -18,8 +18,6 @@ export const isMobile = {
     windows: (agent = navigator.userAgent) => /iemobile/i.test(agent),
     // eslint-disable-next-line max-len
     any: () => (isMobile.android() || isMobile.blackBerry() || isMobile.iOS() || isMobile.opera() || isMobile.windows()),
-    // eslint-disable-next-line max-len
-    tablet: (agent = navigator.userAgent) => /(ipad|tablet|(android(?!.*mobile))|(windows(?!.*phone)(.*touch))|kindle|playbook|silk|(puffin(?!.*(IP|AP|WP))))/i.test(agent),
     standaloneMode: () => window.matchMedia('(display-mode: standalone)').matches
 };
 

--- a/src/config/webpack.development.config.js
+++ b/src/config/webpack.development.config.js
@@ -186,7 +186,10 @@ const config = (env, argv) => {
                         {
                             loader: 'sass-resources-loader',
                             options: {
-                                resources: path.join(fallbackRoot, 'src', 'app', 'style', 'abstract', '_abstract.scss')
+                                resources: path.join(
+                                    env.BUILD_MODE === DEVELOPMENT ? fallbackRoot : projectRoot,
+                                    'src', 'app', 'style', 'abstract', '_abstract.scss'
+                                )
                             }
                         }
                     ]


### PR DESCRIPTION
JS isMobile.tablet API has been removed.

Changes in styles are made to fix some issues on tablets screens <1024px size.

Tested in Chrome Devtools iPads emulation.
<img width="1003" alt="Screenshot 2020-09-24 at 17 56 22" src="https://user-images.githubusercontent.com/18352350/94162346-4636db00-fe8f-11ea-97c4-891e9861576c.png">
<img width="541" alt="Screenshot 2020-09-24 at 17 58 47" src="https://user-images.githubusercontent.com/18352350/94162643-9ada5600-fe8f-11ea-9560-25b2b0cdf318.png">
<img width="585" alt="Screenshot 2020-09-24 at 18 00 02" src="https://user-images.githubusercontent.com/18352350/94162811-c6f5d700-fe8f-11ea-87cf-a708940e97d8.png">

