### PR TITLE
Format prices and currency using Intl library

### DIFF
--- a/src/app/component/CartItemPrice/CartItemPrice.component.js
+++ b/src/app/component/CartItemPrice/CartItemPrice.component.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { MixType } from 'Type/Common';
-import { formatCurrency, roundPrice } from 'Util/Price';
+import { formatPrice, roundPrice } from 'Util/Price';
 
 /** @namespace Component/CartItemPrice/Component */
 export class CartItemPrice extends PureComponent {
@@ -30,7 +30,7 @@ export class CartItemPrice extends PureComponent {
         return (
             <p block="ProductPrice" aria-label={ __('Product Price') } mix={ mix }>
                 <span aria-label={ __('Current product price') }>
-                    <data value={ price }>{ `${formatCurrency(currency_code)}${price}` }</data>
+                    <data value={ price }>{ `${formatPrice(row_total, currency_code)}` }</data>
                 </span>
             </p>
         );

--- a/src/app/component/CartOverlay/CartOverlay.component.js
+++ b/src/app/component/CartOverlay/CartOverlay.component.js
@@ -19,7 +19,7 @@ import Link from 'Component/Link';
 import Overlay from 'Component/Overlay';
 import { DeviceType } from 'Type/Device';
 import { TotalsType } from 'Type/MiniCart';
-import { formatCurrency } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './CartOverlay.style';
 
@@ -45,7 +45,7 @@ export class CartOverlay extends PureComponent {
 
     renderPriceLine(price) {
         const { currencyCode } = this.props;
-        return `${parseFloat(price).toFixed(2)}${formatCurrency(currencyCode)}`;
+        return formatPrice(price, currencyCode);
     }
 
     renderCartItems() {

--- a/src/app/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
+++ b/src/app/component/CategoryConfigurableAttributes/CategoryConfigurableAttributes.component.js
@@ -12,7 +12,7 @@
 import ExpandableContent from 'Component/ExpandableContent';
 // eslint-disable-next-line max-len
 import ProductConfigurableAttributes from 'Component/ProductConfigurableAttributes/ProductConfigurableAttributes.component';
-import { formatCurrency } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 /** @namespace Component/CategoryConfigurableAttributes/Component */
 export class CategoryConfigurableAttributes extends ProductConfigurableAttributes {
@@ -20,17 +20,16 @@ export class CategoryConfigurableAttributes extends ProductConfigurableAttribute
         const { currency_code } = this.props;
         const { value_string } = option;
         const [from, to] = value_string.split('_');
-        const currency = formatCurrency(currency_code);
 
         if (from === '*') {
-            return __('Up to %s%s', to, currency);
+            return __('Up to %s', formatPrice(to, currency_code));
         }
 
         if (to === '*') {
-            return __('From %s%s', from, currency);
+            return __('From %s', formatPrice(from, currency_code));
         }
 
-        return __('From %s%s, to %s%s', from, currency, to, currency);
+        return __('From %s, to %s', formatPrice(from, currency_code), formatPrice(to, currency_code));
     }
 
     renderPriceSwatch(option) {

--- a/src/app/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
+++ b/src/app/component/CheckoutDeliveryOption/CheckoutDeliveryOption.component.js
@@ -14,7 +14,7 @@ import { PureComponent } from 'react';
 
 import { shippingMethodType } from 'Type/Checkout';
 import { TotalsType } from 'Type/MiniCart';
-import { formatCurrency, roundPrice } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './CheckoutDeliveryOption.style';
 
@@ -46,11 +46,10 @@ export class CheckoutDeliveryOption extends PureComponent {
             totals: { quote_currency_code }
         } = this.props;
 
-        const roundedUpPrice = roundPrice(price_incl_tax);
-
+        const formattedPrice = formatPrice(price_incl_tax, quote_currency_code);
         return (
             <strong>
-                { ` - ${roundedUpPrice}${formatCurrency(quote_currency_code)}` }
+                { ` - ${formattedPrice}` }
             </strong>
         );
     }

--- a/src/app/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/src/app/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -15,7 +15,7 @@ import { PureComponent } from 'react';
 import CartItem from 'Component/CartItem';
 import { SHIPPING_STEP } from 'Route/Checkout/Checkout.config';
 import { TotalsType } from 'Type/MiniCart';
-import { formatCurrency, roundPrice } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './CheckoutOrderSummary.style';
 
@@ -41,7 +41,7 @@ export class CheckoutOrderSummary extends PureComponent {
         }
 
         const { totals: { quote_currency_code } } = this.props;
-        const priceString = formatCurrency(quote_currency_code);
+        const priceString = formatPrice(price, quote_currency_code);
 
         return (
             <li block="CheckoutOrderSummary" elem="SummaryItem" mods={ mods }>
@@ -49,7 +49,7 @@ export class CheckoutOrderSummary extends PureComponent {
                     { name }
                 </strong>
                 <strong block="CheckoutOrderSummary" elem="Text">
-                    { `${priceString}${roundPrice(price)}` }
+                    { `${priceString}` }
                 </strong>
             </li>
         );

--- a/src/app/component/MyAccountOrderPopup/MyAccountOrderPopup.component.js
+++ b/src/app/component/MyAccountOrderPopup/MyAccountOrderPopup.component.js
@@ -17,7 +17,7 @@ import Loader from 'Component/Loader';
 import MyAccountAddressTable from 'Component/MyAccountAddressTable';
 import Popup from 'Component/Popup';
 import { orderType } from 'Type/Account';
-import { formatCurrency } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import { ORDER_POPUP_ID } from './MyAccountOrderPopup.config';
 
@@ -98,8 +98,7 @@ export class MyAccountOrderPopup extends PureComponent {
                     </dd>
                     <dt>{ __('Price: ') }</dt>
                     <dd>
-                        { formatCurrency(currency_code) }
-                        { shipping_amount }
+                        { formatPrice(shipping_amount, currency_code) }
                     </dd>
                 </dl>
                 { this.renderShippingAddressTable() }
@@ -139,8 +138,7 @@ export class MyAccountOrderPopup extends PureComponent {
                     <td>{ name }</td>
                     <td>{ qty }</td>
                     <td>
-                        { formatCurrency(currency_code) }
-                        { row_total }
+                        { formatPrice(row_total, currency_code) }
                     </td>
                 </tr>
             );
@@ -187,13 +185,11 @@ export class MyAccountOrderPopup extends PureComponent {
                 <dl>
                     <dt>{ __('Subtotal: ') }</dt>
                     <dd>
-                        { formatCurrency(currency_code) }
-                        { sub_total }
+                        { formatPrice(sub_total, currency_code) }
                     </dd>
                     <dt>{ __('Grand total: ') }</dt>
                     <dd>
-                        { formatCurrency(currency_code) }
-                        { grand_total }
+                        { formatPrice(grand_total, currency_code) }
                     </dd>
                 </dl>
             </div>

--- a/src/app/component/MyAccountOrderTableRow/MyAccountOrderTableRow.component.js
+++ b/src/app/component/MyAccountOrderTableRow/MyAccountOrderTableRow.component.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { baseOrderInfoType } from 'Type/Account';
-import { formatCurrency } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './MyAccountOrderTableRow.style';
 
@@ -43,8 +43,7 @@ export class MyAccountOrderTableRow extends PureComponent {
                 <td>{ created_at }</td>
                 <td>{ status_label }</td>
                 <td block="hidden-mobile">
-                    { /* TODO: get currency symbol */ }
-                    { grand_total ? `${formatCurrency(currency_code)}${grand_total}` : '' }
+                    { grand_total ? formatPrice(grand_total, currency_code) : '' }
                 </td>
             </tr>
         );

--- a/src/app/component/ProductCustomizableOption/ProductCustomizableOption.container.js
+++ b/src/app/component/ProductCustomizableOption/ProductCustomizableOption.container.js
@@ -12,7 +12,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { formatCurrency } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import ProductCustomizableOption from './ProductCustomizableOption.component';
 
@@ -97,7 +97,8 @@ export class ProductCustomizableOptionContainer extends PureComponent {
         case 'PERCENT':
             return `${ price }%`;
         default:
-            return `${ formatCurrency() }${ price }`;
+            /* TODO: get currency code */
+            return formatPrice(price);
         }
     }
 

--- a/src/app/component/ProductPrice/ProductPrice.component.js
+++ b/src/app/component/ProductPrice/ProductPrice.component.js
@@ -29,9 +29,8 @@ export class ProductPrice extends PureComponent {
         roundedRegularPrice: PropTypes.string,
         priceCurrency: PropTypes.string,
         discountPercentage: PropTypes.number,
-        formatedCurrency: PropTypes.string,
+        formattedFinalPrice: PropTypes.string,
         variantsCount: PropTypes.number,
-        currency: PropTypes.string,
         price: PriceType,
         mix: MixType
     };
@@ -41,9 +40,8 @@ export class ProductPrice extends PureComponent {
         roundedRegularPrice: '0',
         priceCurrency: 'USD',
         discountPercentage: 0,
-        formatedCurrency: '0',
+        formattedFinalPrice: '0',
         variantsCount: 0,
-        currency: '$',
         mix: {},
         price: {}
     };
@@ -58,36 +56,37 @@ export class ProductPrice extends PureComponent {
         );
     }
 
+    getCurrencySchema() {
+        const { isSchemaRequired, priceCurrency } = this.props;
+        return isSchemaRequired ? { itemProp: 'priceCurrency', content: priceCurrency } : {};
+    }
+
     getCurrentPriceSchema() {
-        const { isSchemaRequired, variantsCount } = this.props;
+        const { isSchemaRequired, variantsCount, price } = this.props;
+        const content_price = price.minimum_price.final_price
+            ? price.minimum_price.final_price.value : price.minimum_price.regular_price.value;
 
         if (variantsCount > 1) {
-            return isSchemaRequired ? { itemProp: 'lowPrice' } : {};
+            return isSchemaRequired ? { itemProp: 'lowPrice', content: content_price } : {};
         }
 
-        return isSchemaRequired ? { itemProp: 'price' } : {};
+        return isSchemaRequired ? { itemProp: 'price', content: content_price } : {};
     }
 
     renderCurrentPrice() {
         const {
             discountPercentage,
-            formatedCurrency,
-            currency
+            formattedFinalPrice
         } = this.props;
 
-        const schema = this.getCurrentPriceSchema();
+        const priceSchema = this.getCurrentPriceSchema();
 
         // Use <ins></ins> <del></del> to represent new price and the old (deleted) one
         const PriceSemanticElementName = discountPercentage > 0 ? 'ins' : 'span';
 
         return (
             <PriceSemanticElementName>
-                <data
-                  value={ formatedCurrency }
-                >
-                    <span>{ currency }</span>
-                    <span { ...schema }>{ formatedCurrency }</span>
-                </data>
+                <span { ...priceSchema }>{ formattedFinalPrice }</span>
             </PriceSemanticElementName>
         );
     }
@@ -116,11 +115,12 @@ export class ProductPrice extends PureComponent {
     }
 
     renderSchema() {
-        const { isSchemaRequired, priceCurrency } = this.props;
+        const { isSchemaRequired } = this.props;
 
         if (isSchemaRequired) {
+            const currencySchema = this.getCurrencySchema();
             return (
-                <meta itemProp="priceCurrency" content={ priceCurrency } />
+                <meta { ...currencySchema } />
             );
         }
 
@@ -135,8 +135,7 @@ export class ProductPrice extends PureComponent {
                     regular_price
                 } = {}
             } = {},
-            formatedCurrency,
-            currency,
+            formattedFinalPrice,
             mix
         } = this.props;
 
@@ -148,7 +147,7 @@ export class ProductPrice extends PureComponent {
             <p
               block="ProductPrice"
               mix={ mix }
-              aria-label={ `Product price: ${ formatedCurrency }${ currency }` }
+              aria-label={ `Product price: ${formattedFinalPrice}` }
             >
                 { this.renderCurrentPrice() }
                 { this.renderOldPrice() }

--- a/src/app/component/ProductPrice/ProductPrice.container.js
+++ b/src/app/component/ProductPrice/ProductPrice.container.js
@@ -16,7 +16,7 @@ import { MixType } from 'Type/Common';
 import { PriceType } from 'Type/ProductList';
 import {
     calculateFinalPrice,
-    formatCurrency,
+    formatPrice,
     roundPrice
 } from 'Util/Price';
 
@@ -64,15 +64,13 @@ export class ProductPriceContainer extends PureComponent {
 
         const roundedRegularPrice = roundPrice(regularPriceValue);
         const finalPrice = calculateFinalPrice(discountPercentage, minimalPriceValue, regularPriceValue);
-        const formatedCurrency = roundPrice(finalPrice);
-        const currency = formatCurrency(priceCurrency);
+        const formattedFinalPrice = formatPrice(finalPrice, priceCurrency);
 
         return {
             roundedRegularPrice,
             priceCurrency,
             discountPercentage,
-            formatedCurrency,
-            currency
+            formattedFinalPrice
         };
     };
 

--- a/src/app/component/TierPrices/TierPrices.component.js
+++ b/src/app/component/TierPrices/TierPrices.component.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { ProductType } from 'Type/ProductList';
-import { formatCurrency, roundPrice } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './TierPrices.style';
 
@@ -54,16 +54,14 @@ export class TierPrices extends PureComponent {
             return null;
         }
 
-        const formattedCurrency = formatCurrency(currency);
-        const roundedPrice = roundPrice(value);
+        const formattedPrice = formatPrice(value, currency);
 
         return (
             <li block="TierPrices" elem="Item" key={ quantity }>
                 { __(
-                    'Buy %s for %s%s each and ',
+                    'Buy %s for %s each and ',
                     quantity,
-                    formattedCurrency,
-                    roundedPrice
+                    formattedPrice
                 ) }
                 <strong>
                     { __(
@@ -92,11 +90,12 @@ export class TierPrices extends PureComponent {
         const lowestValue = price_tiers
             .reduce((acc, { final_price: { value } }) => (acc < value ? acc : value), price_tiers[0].final_price.value);
 
+        const formattedPrice = formatPrice(lowestValue, currency);
         return (
             <span block="TierPrices" elem="Item" mods={ { isLowest: true } }>
                 { __('As low as ') }
                 <span block="TierPrices" elem="ItemPrice">
-                    { `${ formatCurrency(currency) }${ roundPrice(lowestValue) }` }
+                    { `${ formattedPrice }` }
                 </span>
             </span>
         );

--- a/src/app/route/CartPage/CartPage.component.js
+++ b/src/app/route/CartPage/CartPage.component.js
@@ -21,7 +21,7 @@ import Link from 'Component/Link';
 import ProductLinks from 'Component/ProductLinks';
 import { CROSS_SELL } from 'Store/LinkedProducts/LinkedProducts.reducer';
 import { TotalsType } from 'Type/MiniCart';
-import { formatCurrency, roundPrice } from 'Util/Price';
+import { formatPrice } from 'Util/Price';
 
 import './CartPage.style';
 
@@ -80,7 +80,7 @@ export class CartPage extends PureComponent {
 
     renderPriceLine(price) {
         const { totals: { quote_currency_code } } = this.props;
-        return `${formatCurrency(quote_currency_code)}${roundPrice(price)}`;
+        return formatPrice(price, quote_currency_code);
     }
 
     renderTotalDetails(isMobile = false) {

--- a/src/app/util/Price/Price.js
+++ b/src/app/util/Price/Price.js
@@ -15,6 +15,12 @@ import currencyMap from './Price.config';
 /** @namespace Util/Price/formatCurrency */
 export const formatCurrency = (currency = 'USD') => currencyMap[currency];
 
+/** @namespace Util/Price/formatPrice */
+export const formatPrice = (price, currency = 'USD') => {
+    const language = navigator.languages ? navigator.languages[0] : navigator.language;
+    return new Intl.NumberFormat(language, { style: 'currency', currency }).format(price);
+};
+
 /**
  * Calculate final price
  * @param {Number} discount discount percentage


### PR DESCRIPTION
fixes: #1330 

it is probably a breaking change if others use ProductPrice.component directly as its props schema changed, Util/Price/formatCurrency is not used now in the codebase but could be elsewhere so it is left in the utils file, so it is currencyMap