### PR TITLE
[Issue #928] add meta tag robots for PLP

### DIFF
--- a/src/app/component/Meta/Meta.container.js
+++ b/src/app/component/Meta/Meta.container.js
@@ -24,7 +24,8 @@ export const mapStateToProps = (state) => ({
     title_suffix: state.MetaReducer.title_suffix,
     description: state.MetaReducer.description,
     keywords: state.MetaReducer.keywords,
-    title: state.MetaReducer.title
+    title: state.MetaReducer.title,
+    robots: state.MetaReducer.robots
 });
 
 /** @namespace Component/Meta/Container */
@@ -38,7 +39,8 @@ export class MetaContainer extends PureComponent {
         title_suffix: PropTypes.string,
         description: PropTypes.string,
         keywords: PropTypes.string,
-        title: PropTypes.string
+        title: PropTypes.string,
+        robots: PropTypes.string
     };
 
     static defaultProps = {
@@ -50,7 +52,8 @@ export class MetaContainer extends PureComponent {
         title_suffix: '',
         description: '',
         keywords: '',
-        title: ''
+        title: '',
+        robots: ''
     };
 
     containerProps = () => ({
@@ -83,11 +86,18 @@ export class MetaContainer extends PureComponent {
         return keywords || default_keywords;
     }
 
+    _getRobots() {
+        const { robots } = this.props;
+
+        return robots;
+    }
+
     _getMetadata() {
         const meta = {
             title: this._getTitle(),
             description: this._getDescription(),
-            keywords: this._getKeywords()
+            keywords: this._getKeywords(),
+            robots: this._getRobots()
         };
 
         return this._generateMetaFromMetadata(meta);

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -280,6 +280,7 @@ export class CategoryPageContainer extends PureComponent {
 
         setQueryParams({ sortKey }, location, history);
         setQueryParams({ sortDirection }, location, history);
+        this.updateMeta();
     }
 
     setOfflineNoticeSize = () => {
@@ -473,8 +474,15 @@ export class CategoryPageContainer extends PureComponent {
     }
 
     updateMeta() {
-        const { updateMetaFromCategory, category } = this.props;
-        updateMetaFromCategory(category);
+        const { updateMetaFromCategory, category, history } = this.props;
+        const meta_robots = history.location.search
+            ? 'nofollow, noindex'
+            : 'follow, index';
+
+        updateMetaFromCategory({
+            ...category,
+            meta_robots
+        });
     }
 
     updateBreadcrumbs(isUnmatchedCategory = false) {

--- a/src/app/route/CategoryPage/CategoryPage.container.js
+++ b/src/app/route/CategoryPage/CategoryPage.container.js
@@ -221,7 +221,10 @@ export class CategoryPageContainer extends PureComponent {
             categoryIds,
             category: {
                 id
-            }
+            },
+            currentArgs: {
+                filter
+            } = {}
         } = this.props;
 
         const {
@@ -232,7 +235,10 @@ export class CategoryPageContainer extends PureComponent {
             categoryIds: prevCategoryIds,
             category: {
                 id: prevId
-            }
+            },
+            currentArgs: {
+                filter: prevFilter
+            } = {}
         } = prevProps;
 
         // TODO: category scrolls up when coming from PDP
@@ -264,14 +270,24 @@ export class CategoryPageContainer extends PureComponent {
          * Or if the breadcrumbs were not yet updated after category request,
          * and the category ID expected to load was loaded, update data.
          */
-        if (
-            id !== prevId
-            || (!breadcrumbsWereUpdated && id === categoryIds)
-        ) {
+        const categoryChange = id !== prevId || (!breadcrumbsWereUpdated && id === categoryIds);
+
+        if (categoryChange) {
             this.checkIsActive();
             this.updateMeta();
             this.updateBreadcrumbs();
             this.updateHeaderState();
+        }
+
+        /*
+        ** if category wasn't changed we still need to update meta for correct robots meta tag [#928](https://github.com/scandipwa/base-theme/issues/928)
+        */
+        if (!categoryChange
+            && filter
+            && prevFilter
+            && Object.keys(filter.customFilters).length !== Object.keys(prevFilter.customFilters).length
+        ) {
+            this.updateMeta();
         }
     }
 

--- a/src/app/store/Meta/Meta.dispatcher.js
+++ b/src/app/store/Meta/Meta.dispatcher.js
@@ -71,14 +71,16 @@ export class MetaDispatcher {
     _getCategoryMeta(category) {
         const {
             description, name, canonical_url,
-            meta_title, meta_keyword, meta_description
+            meta_title, meta_keyword, meta_description,
+            meta_robots = 'follow, index'
         } = category;
 
         return {
             description: meta_description || description,
             title: meta_title || name,
             keywords: meta_keyword,
-            canonical_url: `${window.location.origin}${appendWithStoreCode(canonical_url)}`
+            canonical_url: `${window.location.origin}${appendWithStoreCode(canonical_url)}`,
+            robots: meta_robots
         };
     }
 }

--- a/src/app/store/Meta/Meta.reducer.js
+++ b/src/app/store/Meta/Meta.reducer.js
@@ -15,7 +15,8 @@ export const updateEveryTime = [
     'title',
     'description',
     'keywords',
-    'canonical_url'
+    'canonical_url',
+    'robots'
 ];
 
 /** @namespace Store/Meta/Reducer/filterData */
@@ -35,7 +36,8 @@ export const getInitialState = () => ({
     title_suffix: '',
     description: '',
     keywords: '',
-    canonical_url: ''
+    canonical_url: '',
+    robots: ''
 });
 
 /** @namespace Store/Meta/Reducer */


### PR DESCRIPTION
Now tag `<meta name="robots" content="index, follow">` will be added to PLP page without applied filters.
If filters are applied there will be used  `<meta name="robots" content="noindex, nofollow">` tag.