### PR TITLE
[Issue #1378] fallback ismobile to matchMedia instead of user agent

### DIFF
--- a/src/app/component/Router/Router.container.js
+++ b/src/app/component/Router/Router.container.js
@@ -144,7 +144,7 @@ export class RouterContainer extends PureComponent {
         if (isUsingClientHints) {
             const { platform, model } = await isMobileClientHints.getDeviceData();
             updateConfigDevice({
-                isMobile: navigator.userAgentData.mobile,
+                isMobile: isMobile.any(),
                 android: isMobile.android(platform),
                 ios: isMobile.iOS(platform),
                 blackberry: isMobile.blackBerry(model),

--- a/src/app/style/abstract/_media.scss
+++ b/src/app/style/abstract/_media.scss
@@ -10,7 +10,7 @@
  */
 
 @mixin desktop {
-    @media (min-width: 769px) {
+    @media (min-width: 811px) {
         @content;
     }
 }
@@ -24,23 +24,26 @@
 }
 
 @mixin tablet {
-    @media (min-width: 769px)
-        and (max-width: 1023px) {
+    @media (min-width: 811px)
+        and (max-width: 1024px)
+        and (-webkit-min-device-pixel-ratio: 1) {
         @content;
     }
 }
 
 @mixin tablet-portrait {
-    @media (min-width: 769px)
+    @media (min-width: 811px)
         and (max-width: 1023px)
+        and (-webkit-min-device-pixel-ratio: 1)
         and (orientation: portrait) {
         @content;
     }
 }
 
 @mixin tablet-landscape {
-    @media (min-width: 769px)
+    @media(min-width: 811px)
         and (max-width: 1023px)
+        and (-webkit-min-device-pixel-ratio: 1)
         and (orientation: landscape) {
         @content;
     }
@@ -55,7 +58,7 @@
 }
 
 @mixin mobile {
-    @media (max-width: 768px) {
+    @media (max-width: 810px) {
         @content;
     }
 }

--- a/src/app/style/abstract/_media.scss
+++ b/src/app/style/abstract/_media.scss
@@ -10,7 +10,7 @@
  */
 
 @mixin desktop {
-    @media (min-width: 768px) {
+    @media (min-width: 769px) {
         @content;
     }
 }
@@ -24,14 +24,14 @@
 }
 
 @mixin tablet {
-    @media (min-width: 768px)
+    @media (min-width: 769px)
         and (max-width: 1023px) {
         @content;
     }
 }
 
 @mixin tablet-portrait {
-    @media (min-width: 768px)
+    @media (min-width: 769px)
         and (max-width: 1023px)
         and (orientation: portrait) {
         @content;
@@ -39,7 +39,7 @@
 }
 
 @mixin tablet-landscape {
-    @media (min-width: 768px)
+    @media (min-width: 769px)
         and (max-width: 1023px)
         and (orientation: landscape) {
         @content;
@@ -55,7 +55,7 @@
 }
 
 @mixin mobile {
-    @media (max-width: 767px) {
+    @media (max-width: 768px) {
         @content;
     }
 }

--- a/src/app/util/Mobile/isMobile.js
+++ b/src/app/util/Mobile/isMobile.js
@@ -16,7 +16,7 @@ export const isMobile = {
     iOS: (agent = navigator.userAgent) => /iphone|ipod/i.test(agent),
     opera: (agent = navigator.userAgent) => /opera mini/i.test(agent),
     windows: (agent = navigator.userAgent) => /iemobile/i.test(agent),
-    // 768 is base but iPad uses 810 so we need to handle that too.
+    // iPad uses 810 so we need to handle that.
     any: () => window.matchMedia('(max-width: 810px)').matches,
     standaloneMode: () => window.matchMedia('(display-mode: standalone)').matches
 };

--- a/src/app/util/Mobile/isMobile.js
+++ b/src/app/util/Mobile/isMobile.js
@@ -16,14 +16,13 @@ export const isMobile = {
     iOS: (agent = navigator.userAgent) => /iphone|ipod/i.test(agent),
     opera: (agent = navigator.userAgent) => /opera mini/i.test(agent),
     windows: (agent = navigator.userAgent) => /iemobile/i.test(agent),
-    // eslint-disable-next-line max-len
-    any: () => window.matchMedia('(max-width: 768px)').matches,
+    // 768 is base but iPad uses 810 so we need to handle that too.
+    any: () => window.matchMedia('(max-width: 810px)').matches,
     standaloneMode: () => window.matchMedia('(display-mode: standalone)').matches
 };
 
 // https://medium.com/@galmeiri/get-ready-for-chrome-user-agent-string-phase-out-c6840da1c31e
 export const isMobileClientHints = {
-    any: () => navigator.userAgentData.mobile,
     getDeviceData: () => navigator.userAgentData.getHighEntropyValues(['platform', 'model'])
 };
 

--- a/src/app/util/Mobile/isMobile.js
+++ b/src/app/util/Mobile/isMobile.js
@@ -17,7 +17,7 @@ export const isMobile = {
     opera: (agent = navigator.userAgent) => /opera mini/i.test(agent),
     windows: (agent = navigator.userAgent) => /iemobile/i.test(agent),
     // eslint-disable-next-line max-len
-    any: () => (isMobile.android() || isMobile.blackBerry() || isMobile.iOS() || isMobile.opera() || isMobile.windows()),
+    any: () => window.matchMedia('(max-width: 768px)').matches,
     standaloneMode: () => window.matchMedia('(display-mode: standalone)').matches
 };
 


### PR DESCRIPTION
Now `isMobile` will use [Window.matchMedia API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) for device screen detection.
This will bring a consistent view to render since we're using the same API that is used in CSS for styling based on [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).