### PR TITLE
[Issue #1356] product is not available on BE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "scandipwa/persisted-query": "^2.4",
         "scandipwa/slider-graphql": "^2.0",
         "scandipwa/cms-graphql": "^1.3",
-        "scandipwa/catalog-graphql": "^2.15.3",
+        "scandipwa/catalog-graphql": "^2.16.1",
         "scandipwa/route717": "^1.7",
         "scandipwa/performance": "^1.1",
         "scandipwa/customer-graph-ql": "^2.2.3",

--- a/src/app/component/CartItem/CartItem.component.js
+++ b/src/app/component/CartItem/CartItem.component.js
@@ -283,8 +283,8 @@ export class CartItem extends PureComponent {
               elem="Content"
               mods={ { isLikeTable } }
             >
-                { this.renderProductName() }
                 { this.renderOutOfStockMessage() }
+                { this.renderProductName() }
                 { this.renderProductOptions(customizable_options) }
                 { this.renderProductOptions(bundle_options) }
                 { this.renderProductConfigurations() }

--- a/src/app/component/CartItem/CartItem.style.scss
+++ b/src/app/component/CartItem/CartItem.style.scss
@@ -162,10 +162,6 @@
     &-Picture {
         align-self: center;
         padding-bottom: 120%;
-
-        &_isNotAvailable {
-            filter: grayscale(1);
-        }
     }
 
     &-Price {

--- a/src/app/util/Cart/Cart.js
+++ b/src/app/util/Cart/Cart.js
@@ -36,8 +36,11 @@ export const itemIsOutOfStock = (item) => {
         return false;
     }
 
-    if (variants.some(({ sku }) => sku === itemSku)) {
-        // item added to cart is present in variants
+    if (
+        variants.some(({ sku }) => sku === itemSku)
+        && variants.find(({ sku }) => sku === itemSku).stock_status !== PRODUCT_OUT_OF_STOCK
+    ) {
+        // item added to cart is present in variants and it stock status is IN_STOCK
         return false;
     }
 


### PR DESCRIPTION
This is an additional fix to the #973 issue.
Must be used with [this PR](https://github.com/scandipwa/catalog-graphql/pull/68) for BE module [catalog/graphql](https://github.com/scandipwa/catalog-graphql).

The grayscale filter on the product image has been removed.
Out of stock message now appears on top of the cart item.
![Screenshot_20201008_175115](https://user-images.githubusercontent.com/18352350/95475411-dd6f5880-098e-11eb-9760-dde4989153f7.png)
