### PR TITLE
[Issue #1399] use default review_summary object if there's no reviews on BE

### DIFF
--- a/src/app/util/Product/Product.js
+++ b/src/app/util/Product/Product.js
@@ -157,23 +157,40 @@ export const getIndexedCustomOptions = (options) => options.reduce(
     []
 );
 
+/** @namespace Util/Product/getIndexedProductReviewSummary */
+export const getIndexedProductReviewSummary = (review_summary) => {
+    if (!review_summary) {
+        return {
+            rating_summary: null,
+            review_count: null
+        };
+    }
+
+    return {
+        ...review_summary
+    };
+};
+
 /** @namespace Util/Product/getIndexedProduct */
 export const getIndexedProduct = (product) => {
     const {
         variants: initialVariants = [],
         configurable_options: initialConfigurableOptions = [],
         attributes: initialAttributes = [],
-        options: initialOptions = []
+        options: initialOptions = [],
+        review_summary: initialReviewSummary
     } = product;
 
     const attributes = getIndexedAttributes(initialAttributes || []);
+    const review_summary = getIndexedProductReviewSummary(initialReviewSummary);
 
     return {
         ...product,
         configurable_options: getIndexedConfigurableOptions(initialConfigurableOptions, attributes),
         variants: getIndexedVariants(initialVariants),
         options: getIndexedCustomOptions(initialOptions || []),
-        attributes
+        attributes,
+        review_summary
     };
 };
 


### PR DESCRIPTION
No more review_summary error on FE if there're no reviews on the website.