### PR TITLE
SWPWA-1406 Discount/Coupon logic adjust render in summary blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "scandipwa/route717": "^1.7",
         "scandipwa/performance": "^1.1",
         "scandipwa/customer-graph-ql": "^2.2.3",
-        "scandipwa/quote-graphql": "^2.14.1",
+        "scandipwa/quote-graphql": "^2.15.1",
         "scandipwa/wishlist-graphql": "^1.2",
         "scandipwa/urlrewrite-graphql": "^1.2.1",
         "scandipwa/reviews-graphql": "^1.6",

--- a/src/app/component/CartOverlay/CartOverlay.component.js
+++ b/src/app/component/CartOverlay/CartOverlay.component.js
@@ -113,10 +113,30 @@ export class CartOverlay extends PureComponent {
     }
 
     renderDiscount() {
-        const { totals: { coupon_code, discount_amount = 0 } } = this.props;
+        const {
+            totals: {
+                applied_rule_ids,
+                discount_amount,
+                coupon_code
+            }
+        } = this.props;
+
+        if (!applied_rule_ids) {
+            return null;
+        }
 
         if (!coupon_code) {
-            return null;
+            return (
+                <dl
+                  block="CartOverlay"
+                  elem="Discount"
+                >
+                    <dt>
+                        { __('Discount: ') }
+                    </dt>
+                    <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>
+                </dl>
+            );
         }
 
         return (
@@ -125,7 +145,7 @@ export class CartOverlay extends PureComponent {
               elem="Discount"
             >
                 <dt>
-                    { __('Coupon ') }
+                    { __('Discount/Coupon ') }
                     <strong block="CartOverlay" elem="DiscountCoupon">{ coupon_code.toUpperCase() }</strong>
                 </dt>
                 <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>

--- a/src/app/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
+++ b/src/app/component/CheckoutOrderSummary/CheckoutOrderSummary.component.js
@@ -71,21 +71,29 @@ export class CheckoutOrderSummary extends PureComponent {
         );
     };
 
-    renderCouponCode() {
+    renderDiscount() {
         const {
             totals: {
+                applied_rule_ids,
                 discount_amount,
                 coupon_code
             }
         } = this.props;
 
-        if (!coupon_code) {
+        if (!applied_rule_ids) {
             return null;
+        }
+
+        if (!coupon_code) {
+            return this.renderPriceLine(
+                -Math.abs(discount_amount),
+                __('Discount %s:', '')
+            );
         }
 
         return this.renderPriceLine(
             -Math.abs(discount_amount),
-            __('Coupon %s:', coupon_code.toUpperCase())
+            __('Discount/Coupon %s:', coupon_code.toUpperCase())
         );
     }
 
@@ -135,7 +143,7 @@ export class CheckoutOrderSummary extends PureComponent {
                     { checkoutStep !== SHIPPING_STEP
                         ? this.renderPriceLine(shipping_amount, __('Shipping'), { divider: true })
                         : null }
-                    { this.renderCouponCode() }
+                    { this.renderDiscount() }
                     { this.renderPriceLine(tax_amount, __('Tax')) }
                     { checkoutStep !== SHIPPING_STEP
                         ? this.renderPriceLine(grand_total, __('Order total'))

--- a/src/app/query/Cart.query.js
+++ b/src/app/query/Cart.query.js
@@ -103,6 +103,7 @@ export class CartQuery {
             'coupon_code',
             'shipping_amount',
             'is_virtual',
+            'applied_rule_ids',
             this._getCartItemsField()
         ];
     }

--- a/src/app/route/CartPage/CartPage.component.js
+++ b/src/app/route/CartPage/CartPage.component.js
@@ -182,19 +182,31 @@ export class CartPage extends PureComponent {
     renderDiscount() {
         const {
             totals: {
+                applied_rule_ids,
                 coupon_code,
                 discount_amount = 0
             }
         } = this.props;
 
-        if (!coupon_code) {
+        if (!applied_rule_ids) {
             return null;
+        }
+
+        if (!coupon_code) {
+            return (
+                <>
+                    <dt>
+                        { __('Discount: ') }
+                    </dt>
+                    <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>
+                </>
+            );
         }
 
         return (
             <>
                 <dt>
-                    { __('Coupon ') }
+                    { __('Discount/Coupon ') }
                     <strong block="CartPage" elem="DiscountCoupon">{ coupon_code.toUpperCase() }</strong>
                 </dt>
                 <dd>{ `-${this.renderPriceLine(Math.abs(discount_amount))}` }</dd>


### PR DESCRIPTION
Hello!
Changes will work only if add 'applied_rule_ids' field to graphql. (https://github.com/scandipwa/quote-graphql/pull/38)
If applied_rule_ids is null then no discount in cart.
If applied_rule_ids is not null, but coupon_code is null then show discount not as coupon.