### PR TITLE
Fixed #1366 Update Password on Forgot Password Page Doesn't Work

### DIFF
--- a/src/app/route/PasswordChangePage/PasswordChangePage.container.js
+++ b/src/app/route/PasswordChangePage/PasswordChangePage.container.js
@@ -167,6 +167,7 @@ export class PasswordChangePageContainer extends PureComponent {
         return (
             <PasswordChangePage
               { ...this.containerProps() }
+              { ...this.containerFunctions }
             />
         );
     }


### PR DESCRIPTION
Fixed #1366 Update Password on Forgot Password Page Doesn't Work

Description:
When we click on Forgot your account password? Click here to reset it. in Email, we landing to Update Password Page.
Fill all inputs
Push Update Password
And nothing is happening.

Demo - https://prnt.sc/urrgix
Local - https://prnt.sc/urrn4t

Versions:

ScandiPWA: 2.16.2 locally and on Demo