### PR TITLE
SWPWA-1459 - Accept getting null value for guest_quote_id

### DIFF
--- a/src/app/query/MyAccount.query.js
+++ b/src/app/query/MyAccount.query.js
@@ -48,7 +48,7 @@ export class MyAccountQuery {
         return new Field('generateCustomerToken')
             .addArgument('email', 'String!', email)
             .addArgument('password', 'String!', password)
-            .addArgument('guest_quote_id', 'String!', guestQuoteId)
+            .addArgument('guest_quote_id', 'String', guestQuoteId)
             .addField('token');
     }
 


### PR DESCRIPTION
To reproduce error:
1. No items in cart
2. Clear local storage

Basically in customer-graph-ql last version it is allowed for guest_quote_id to be null https://github.com/scandipwa/customer-graph-ql/commit/7ed84251fe59698c7e5e8876ce7362087a4cbfdd. But in MyAccount.query.js it is not allowed to be null. Since that error appears when receiving data from query and now it is allowed in query also to be null.
Tested. Seems all to work.