### PR TITLE
SWPWA-1511 Create new empty cart after guest complete order

### DIFF
--- a/src/app/store/Cart/Cart.dispatcher.js
+++ b/src/app/store/Cart/Cart.dispatcher.js
@@ -31,14 +31,10 @@ export const GUEST_QUOTE_ID = 'guest_quote_id';
  */
 export class CartDispatcher {
     updateInitialCartData(dispatch) {
-        const guestQuoteId = this._getGuestQuoteId();
-
         if (isSignedIn()) {
-            // This is logged in customer, no need for quote id
             this._syncCartWithBE(dispatch);
-        } else if (guestQuoteId) {
-            // This is guest
-            this._syncCartWithBE(dispatch, guestQuoteId);
+        } else {
+            this.createGuestEmptyCart(dispatch);
         }
     }
 


### PR DESCRIPTION
If guest is making an order then cart is not updated on FE since guest_quote_id is null and cart is showing cart_id= error since on BE it is gone. So if guest makes an order then after just create new empty cart for guest.