### PR TITLE
#1392 Favicon change through admin / M2 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "scandipwa/wishlist-graphql": "^2",
         "scandipwa/urlrewrite-graphql": "^1.3.1",
         "scandipwa/store-graphql": "^1.1.1",
-        "scandipwa/customization": "^1.1",
+        "scandipwa/customization": "^1.3",
         "scandipwa/cache": "^1.1.1",
         "scandipwa/locale": "^1.1.1"
     },

--- a/src/config/webpack.development.config.js
+++ b/src/config/webpack.development.config.js
@@ -18,12 +18,10 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const WebpackPwaManifest = require('webpack-pwa-manifest');
 const autoprefixer = require('autoprefixer');
 
 const FallbackPlugin = require('./Extensibility/plugins/FallbackPlugin');
 
-const webmanifestConfig = require('./webmanifest.config');
 const { getBabelConfig } = require('./babel.config');
 
 const projectRoot = path.resolve(__dirname, '..', '..');
@@ -267,8 +265,6 @@ const config = (env, argv) => {
                 publicPath: '/',
                 chunksSortMode: 'none'
             }),
-
-            new WebpackPwaManifest(webmanifestConfig(projectRoot)),
 
             new CopyWebpackPlugin([
                 { from: path.resolve(projectRoot, 'src', 'public', 'assets'), to: './assets' }

--- a/src/config/webpack.production.config.js
+++ b/src/config/webpack.production.config.js
@@ -18,12 +18,10 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const WebpackPwaManifest = require('webpack-pwa-manifest');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
 
-const webmanifestConfig = require('./webmanifest.config');
 const { getBabelConfig } = require('./babel.config');
 const FallbackPlugin = require('./Extensibility/plugins/FallbackPlugin');
 const { I18nPlugin, mapTranslationsToConfig } = require('./I18nPlugin');
@@ -170,8 +168,6 @@ const webpackConfig = ([lang, translation]) => ({
             publicPath,
             chunksSortMode: 'none'
         }),
-
-        new WebpackPwaManifest(webmanifestConfig(projectRoot)),
 
         new webpack.DefinePlugin({
             'process.env': {

--- a/src/public/index.development.html
+++ b/src/public/index.development.html
@@ -67,7 +67,10 @@
 
         <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[0] %>">
 
-        <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>assets/favicon/favicon.ico">
+        <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
+        <link rel="icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
+        <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>media/webmanifest/manifest.webmanifest">
+        
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 
     </head>

--- a/src/public/index.production.phtml
+++ b/src/public/index.production.phtml
@@ -1,6 +1,7 @@
 <?php
     $colorConfig = $this->getThemeConfiguration('color_customization');
     $contentConfig = $this->getThemeConfiguration('content_customization');
+    $icons = $this->getAppIconData();
 ?>
 
 <!DOCTYPE html>
@@ -84,7 +85,17 @@
             }
         </style>
 
-        <link rel="shortcut icon" href="<?= $this->getStaticFile("assets/favicon/favicon.ico"); ?>">
+        <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
+       
+        <?php foreach ($icons['ios_startup'] as $icon): ?>
+            <?= sprintf(' <link rel="apple-touch-startup-image" sizes="%s" href="%s">;', $icon["sizes"], $icon["href"]); ?>
+        <?php endforeach; ?>
+
+        <?php foreach ($icons['icon'] as $icon): ?>
+            <?= sprintf(' <link rel="icon" sizes="%s" href="%s">;', $icon["sizes"], $icon["href"]); ?>
+        <?php endforeach; ?>
+
+        <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>media/webmanifest/manifest.webmanifest">
 
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     </head>


### PR DESCRIPTION
While fixing this issue, there was need to create new customizable options for Webmanifest support, so please first check pull request in scandipwa/customization: https://github.com/scandipwa/customization/pull/3

In this task main goal was to replace static .ico file that was located in public/assets/favicon to M2 admin panel defined favicon, for that reason path for favicon is changed to "media/favicon/favicon.png" as Magento uploads files to this folder.

Other issue was that webmanifest nodejs module was overriding icons with static icon, and changing location target path may cause crashes on redeployment, as its only generated on that time. To fix this there new support for webmanifest & favicons was created (_check above mentioned pull request_) that uses M2 favicon as appicon and admin panel configurations for generation of manifest file.