### PR TITLE
#1650 Hide empty attributes. Textarea, media_image support

### DIFF
--- a/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
+++ b/src/app/component/ProductAttributeValue/ProductAttributeValue.component.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import Field from 'Component/Field';
+import Html from 'Component/Html';
 import { MixType } from 'Type/Common';
 import { AttributeType } from 'Type/ProductList';
 
@@ -121,6 +122,43 @@ export class ProductAttributeValue extends PureComponent {
         default:
             return this.renderStringValue(label || __('N/A'));
         }
+    }
+
+    renderImageAttribute() {
+        const {
+            attribute: {
+                attribute_label,
+                attribute_value
+            }
+        } = this.props;
+
+        if (!attribute_value || attribute_value === 'no_selection') {
+            return this.renderPlaceholder();
+        }
+
+        return (
+            <img
+              block="ProductAttributeValue"
+              elem="MediaImage"
+              src={ `/media/catalog/product${attribute_value}` }
+              alt={ attribute_label }
+            />
+        );
+    }
+
+    renderTextAreaAttribute() {
+        const {
+            attribute: { attribute_value }
+        } = this.props;
+
+        return (
+            <div
+              block="ProductAttributeValue"
+              elem="TextArea"
+            >
+                <Html content={ attribute_value } />
+            </div>
+        );
     }
 
     renderPlaceholder() {
@@ -240,6 +278,10 @@ export class ProductAttributeValue extends PureComponent {
             return this.renderTextAttribute();
         case 'multiselect':
             return this.renderMultiSelectAttribute();
+        case 'media_image':
+            return this.renderImageAttribute();
+        case 'textarea':
+            return this.renderTextAreaAttribute();
         default:
             return this.renderPlaceholder();
         }

--- a/src/app/component/ProductInformation/ProductInformation.component.js
+++ b/src/app/component/ProductInformation/ProductInformation.component.js
@@ -28,7 +28,7 @@ export class ProductInformation extends PureComponent {
         attributesWithValues: AttributeType.isRequired
     };
 
-    renderAttribute = ([attributeLabel, valueLabel]) => (
+    renderAttribute = ([attributeLabel, valueLabel]) => (!this.isEmpty(valueLabel) && !this.isEmpty(attributeLabel) ? (
         <Fragment key={ attributeLabel }>
             <dt block="ProductInformation" elem="AttributeLabel">
                 { attributeLabel }
@@ -41,7 +41,11 @@ export class ProductInformation extends PureComponent {
                 />
             </dd>
         </Fragment>
-    );
+    ) : null);
+
+    isEmpty(object) {
+        return (!object || object === 'null' || object.length === 0);
+    }
 
     renderAttributes() {
         const { attributesWithValues } = this.props;


### PR DESCRIPTION
Original issue: #1650 
## Issue requirements:
Don't need show these attributes:
- empty
- we see in another place (short description, URL and etc)

## Requited PR to work:
- https://github.com/scandipwa/performance/pull/11

## In this PR:
- Some values where empty due to unsupported attribute types: "textarea", "media_image", thus I added support for rendering.
- Removed from displaying attributes with: "null" or empty values.

## How to remove attributes from product information:
There was no need to implement support for removal of repeating product attributes in PDP as they can be disabled in BE admin panel: _Stores -> attributes -> Product -> [Select specific_attribute] -> StoreFront Properties -> Used in product listing -> No_