### PR TITLE
#1392 Fixed url paths for favicon & manifest

### DIFF
--- a/src/public/index.development.html
+++ b/src/public/index.development.html
@@ -69,7 +69,7 @@
 
         <link rel="shortcut icon" href="/pub/media/favicon/favicon.png">
         <link rel="icon" href="/pub/media/favicon/favicon.png">
-        <link rel="manifest" href="/pub/media/webmanifest/manifest.webmanifest">
+        <link rel="manifest" href="/pub/media/webmanifest/manifest.json">
         
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 

--- a/src/public/index.development.html
+++ b/src/public/index.development.html
@@ -67,9 +67,9 @@
 
         <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[0] %>">
 
-        <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
-        <link rel="icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
-        <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>media/webmanifest/manifest.webmanifest">
+        <link rel="shortcut icon" href="/pub/media/favicon/favicon.png">
+        <link rel="icon" href="/pub/media/favicon/favicon.png">
+        <link rel="manifest" href="/pub/media/webmanifest/manifest.webmanifest">
         
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 

--- a/src/public/index.production.phtml
+++ b/src/public/index.production.phtml
@@ -90,6 +90,10 @@
         <?php foreach ($icons['ios_startup'] as $icon): ?>
             <?= sprintf('<link rel="apple-touch-startup-image" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
         <?php endforeach; ?>
+        
+        <?php foreach ($icons['ios'] as $icon): ?>
+            <?= sprintf('<link rel="apple-touch-icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
+        <?php endforeach; ?>
 
         <?php foreach ($icons['icon'] as $icon): ?>
             <?= sprintf('<link rel="icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>

--- a/src/public/index.production.phtml
+++ b/src/public/index.production.phtml
@@ -85,17 +85,17 @@
             }
         </style>
 
-        <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>media/favicon/favicon.png">
-       
+        <link rel="shortcut icon" href="/pub/media/favicon/favicon.png">
+
         <?php foreach ($icons['ios_startup'] as $icon): ?>
-            <?= sprintf(' <link rel="apple-touch-startup-image" sizes="%s" href="%s">;', $icon["sizes"], $icon["href"]); ?>
+            <?= sprintf('<link rel="apple-touch-startup-image" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
         <?php endforeach; ?>
 
         <?php foreach ($icons['icon'] as $icon): ?>
-            <?= sprintf(' <link rel="icon" sizes="%s" href="%s">;', $icon["sizes"], $icon["href"]); ?>
+            <?= sprintf('<link rel="icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
         <?php endforeach; ?>
 
-        <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>media/webmanifest/manifest.webmanifest">
+        <link rel="manifest" href="/pub/media/webmanifest/manifest.webmanifest">
 
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     </head>

--- a/src/public/index.production.phtml
+++ b/src/public/index.production.phtml
@@ -95,7 +95,7 @@
             <?= sprintf('<link rel="icon" sizes="%s" href="%s">', $icon["sizes"], $icon["href"]); ?>
         <?php endforeach; ?>
 
-        <link rel="manifest" href="/pub/media/webmanifest/manifest.webmanifest">
+        <link rel="manifest" href="/pub/media/webmanifest/manifest.json">
 
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     </head>


### PR DESCRIPTION
- Updated paths to correct url
- Removed ";" in \<link\> generation
- Favicon updates without Magento cache cleaning (requires local refresh)

Requires this PR to work: https://github.com/scandipwa/customization/pull/5