### PR TITLE
Customer Address getting duplicated when an order is placed

### DIFF
--- a/src/app/component/CheckoutBilling/CheckoutBilling.container.js
+++ b/src/app/component/CheckoutBilling/CheckoutBilling.container.js
@@ -206,7 +206,10 @@ export class CheckoutBillingContainer extends PureComponent {
         const { customer: { addresses } } = this.props;
         const address = addresses.find(({ id }) => id === selectedCustomerAddressId);
 
-        return trimCustomerAddress(address);
+        return {
+            ...trimCustomerAddress(address),
+            save_in_address_book: false
+        };
     }
 
     render() {

--- a/src/app/component/CheckoutShipping/CheckoutShipping.container.js
+++ b/src/app/component/CheckoutShipping/CheckoutShipping.container.js
@@ -110,7 +110,10 @@ export class CheckoutShippingContainer extends PureComponent {
     _getAddressById(addressId) {
         const { customer: { addresses } } = this.props;
         const address = addresses.find(({ id }) => id === addressId);
-        return trimCustomerAddress(address);
+        return {
+            ...trimCustomerAddress(address),
+            save_in_address_book: false
+        };
     }
 
     render() {

--- a/src/app/route/Checkout/Checkout.container.js
+++ b/src/app/route/Checkout/Checkout.container.js
@@ -445,6 +445,26 @@ export class CheckoutContainer extends PureComponent {
         return true;
     }
 
+    prepareAddressInformation(addressInformation) {
+        const {
+            shipping_address: {
+                save_in_address_book,
+                ...shippingAddress
+            } = {},
+            billing_address: {
+                save_in_address_book: x,
+                ...billingAddress
+            } = {},
+            ...data
+        } = addressInformation;
+
+        return {
+            ...data,
+            shipping_address: shippingAddress,
+            billing_address: billingAddress
+        };
+    }
+
     async saveAddressInformation(addressInformation) {
         const { updateShippingPrice } = this.props;
         const { shipping_address } = addressInformation;
@@ -462,7 +482,7 @@ export class CheckoutContainer extends PureComponent {
         }
 
         fetchMutation(CheckoutQuery.getSaveAddressInformation(
-            addressInformation,
+            this.prepareAddressInformation(addressInformation),
             this._getGuestCartId()
         )).then(
             /** @namespace Route/Checkout/Container/saveAddressInformationFetchMutationThen */


### PR DESCRIPTION
Fixes #1436
Added an option for billing request in order to prevent customer address duplicating