### PR TITLE
Fixed popup component behaviour on store switch

### DIFF
--- a/src/app/component/CookiePopup/CookiePopup.component.js
+++ b/src/app/component/CookiePopup/CookiePopup.component.js
@@ -26,12 +26,13 @@ export class CookiePopup extends PureComponent {
     static propTypes = {
         cookieText: PropTypes.string,
         cookieLink: PropTypes.string,
-        code: PropTypes.string.isRequired
+        code: PropTypes.string
     };
 
     static defaultProps = {
         cookieText: '',
-        cookieLink: ''
+        cookieLink: '',
+        code: ''
     };
 
     state = {

--- a/src/app/component/CookiePopup/CookiePopup.container.js
+++ b/src/app/component/CookiePopup/CookiePopup.container.js
@@ -9,6 +9,8 @@
  * @link https://github.com/scandipwa/base-theme
  */
 
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import CookiePopup from './CookiePopup.component';
@@ -24,4 +26,26 @@ export const mapStateToProps = (state) => ({
 // eslint-disable-next-line no-unused-vars
 export const mapDispatchToProps = (dispatch) => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(CookiePopup);
+/** @namespace Component/CookiePopup/Container */
+export class CookiePopupContainer extends PureComponent {
+    static propTypes = {
+        code: PropTypes.string
+    };
+
+    static defaultProps = {
+        code: ''
+    };
+
+    render() {
+        const { code } = this.props;
+
+        return (
+            <CookiePopup
+              { ...this.props }
+              key={ code }
+            />
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CookiePopupContainer);

--- a/src/app/component/Link/Link.container.js
+++ b/src/app/component/Link/Link.container.js
@@ -21,7 +21,7 @@ import Link from './Link.component';
 
 /** @namespace Component/Link/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
-    baseLinkUrl: state.ConfigReducer.base_link_url
+    baseLinkUrl: state.ConfigReducer.base_link_url || ''
 });
 
 /** @namespace Component/Link/Container */

--- a/src/app/component/StoreSwitcher/StoreSwitcher.config.js
+++ b/src/app/component/StoreSwitcher/StoreSwitcher.config.js
@@ -1,0 +1,13 @@
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/base-theme
+ * @link https://github.com/scandipwa/base-theme
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export const STORE_CONFIG_KEY = 'config';

--- a/src/app/component/StoreSwitcher/StoreSwitcher.container.js
+++ b/src/app/component/StoreSwitcher/StoreSwitcher.container.js
@@ -14,9 +14,11 @@ import { connect } from 'react-redux';
 
 import ConfigQuery from 'Query/Config.query';
 import { showNotification } from 'Store/Notification/Notification.action';
+import BrowserDatabase from 'Util/BrowserDatabase/BrowserDatabase';
 import DataContainer from 'Util/Request/DataContainer';
 
 import StoreSwitcher from './StoreSwitcher.component';
+import { STORE_CONFIG_KEY } from './StoreSwitcher.config';
 
 /** @namespace Component/StoreSwitcher/Container/mapStateToProps */
 export const mapStateToProps = (state) => ({
@@ -144,6 +146,7 @@ export class StoreSwitcherContainer extends DataContainer {
             return;
         }
 
+        BrowserDatabase.deleteItem(STORE_CONFIG_KEY);
         window.location = store.storeLinkUrl;
     }
 


### PR DESCRIPTION
Just right after the store was switched, redux took the previous store config from the localStorage.
And after a moment a new store config were arriving from the backend.
But CookiePopup component took old store code and thus it didn't behave correctly.

Now before store is switched the config is removed from the localStorage.
Now after store was switched, it acts like is was loaded in a clean browser.

Additionally i've fixed errors from the console, that appeared when website was loaded in a browser with a clean localStorage.